### PR TITLE
Feature/support binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Resulting benefits:
   will actually monitor that the most useful and frequently used user workflows
   are working end-to-end.
 
-[pytest](https://pytest.org/) is used as test framework together with
-[nbval](https://github.com/computationalmodelling/nbval) pytest plugin to
+[nbval](https://github.com/computationalmodelling/nbval) pytest plugin used to
 validate Jupyter notebooks.
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Ouranosinc/PAVICS-e2e-workflow-tests/master)
 
 
 ## Run locally
@@ -62,8 +63,6 @@ DISABLE_VERIFY_SSL=1 ./runtest
 #     different run
 SAVE_RESULTING_NOTEBOOK=true ./runtest
 ```
-
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Ouranosinc/PAVICS-e2e-workflow-tests/master)
 
 ## Design considerations
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ DISABLE_VERIFY_SSL=1 ./runtest
 SAVE_RESULTING_NOTEBOOK=true ./runtest
 ```
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Ouranosinc/PAVICS-e2e-workflow-tests/master?filepath=notebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Ouranosinc/PAVICS-e2e-workflow-tests/master)
 
 ## Design considerations
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ DISABLE_VERIFY_SSL=1 ./runtest
 SAVE_RESULTING_NOTEBOOK=true ./runtest
 ```
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Ouranosinc/PAVICS-e2e-workflow-tests/master?filepath=notebooks)
+
 ## Design considerations
 
 Since the runtime environment is provided by the Docker container, it is not

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,3 +1,14 @@
 FROM pavics/workflow-tests:190503
 
+USER root
+
 COPY notebooks /notebooks
+
+COPY default_build_params /notebooks
+COPY downloadrepos /notebooks
+
+WORKDIR /notebooks
+
+RUN ./downloadrepos; mv -v pavics-sdi-*/docs/source/notebooks/*.ipynb ./; rm -rfv downloadrepos default_build_params pavics-sdi-*; chown -R jenkins:jenkins .
+
+USER jenkins

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,3 @@
+FROM pavics/workflow-tests:190503
+
+COPY notebooks /notebooks

--- a/releasedocker
+++ b/releasedocker
@@ -11,8 +11,9 @@ update_ver() {
 update_ver launchcontainer
 update_ver launchnotebook
 update_ver Jenkinsfile
+update_ver binder/Dockerfile
 
-git add launchcontainer launchnotebook Jenkinsfile
+git add launchcontainer launchnotebook Jenkinsfile binder/Dockerfile
 git st -v
 echo "Looks good to commit? (Ctrl-C to abort)"; read a
 


### PR DESCRIPTION
See it in action here https://mybinder.org/v2/gh/Ouranosinc/PAVICS-e2e-workflow-tests/feature/support-binder

We basically can demo the notebooks from anywhere.  Binder launches a Jupyter notebook server on demand for us so we do not even have to host a Jupyter notebook ourselves. 

This is fully for demo purposes since there are no persistence and the on demand server will be killed very fast if no activity.