### PR TITLE
add raven notebooks, download only, not running by Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # extra repos downloaded
 pavics-sdi-*/
+raven-*/
 esgf-compute-api-*/
 
 # files produced by build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,8 @@ pipeline {
                description: 'PAVICS host to run notebooks against.', trim: true)
         string(name: 'PAVICS_SDI_BRANCH', defaultValue: 'master',
                description: 'https://github.com/Ouranosinc/pavics-sdi branch to test against.', trim: true)
+//        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
+//               description: 'https://github.com/Ouranosinc/raven branch to test against.', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                      description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,

--- a/default_build_params
+++ b/default_build_params
@@ -5,4 +5,9 @@ else
     echo "PAVICS_SDI_BRANCH has been set to '$PAVICS_SDI_BRANCH'"
 fi
 
-
+if [ -z "$RAVEN_BRANCH" ]; then
+    RAVEN_BRANCH=master
+    echo "RAVEN_BRANCH not set, default to '$RAVEN_BRANCH'"
+else
+    echo "RAVEN_BRANCH has been set to '$RAVEN_BRANCH'"
+fi

--- a/downloadrepos
+++ b/downloadrepos
@@ -8,15 +8,23 @@ downloadrepos() {
         $github_repo/archive/${branch}.tar.gz | tar xz
 }
 
+downloadouranosrepos() {
+    repo_name="$1"; shift
+    repo_branch="$1"; shift
+    set -x
+    # clean up other previously downloaded branches of the same repo as well
+    rm -rf ${repo_name}-*
+    ls | grep $repo_name
+    downloadrepos https://github.com/Ouranosinc/$repo_name $repo_branch
+    ls | grep $repo_name
+    set +x
+}
+
 . ./default_build_params
 
 if [ -z "$1" ]; then
-    set -x
-    # clean up other previously downloaded branches of the same repo as well
-    rm -rf pavics-sdi-*
-    ls | grep pavics-sdi
-    downloadrepos https://github.com/Ouranosinc/pavics-sdi $PAVICS_SDI_BRANCH
-    ls | grep pavics-sdi
+    downloadouranosrepos pavics-sdi $PAVICS_SDI_BRANCH
+    downloadouranosrepos raven $RAVEN_BRANCH
 else
     set -x
     downloadrepos "$@"

--- a/testall
+++ b/testall
@@ -14,6 +14,7 @@ git clean -fdx
 # for branch name of the format "feature/my_wizbang-feature"
 # github does the same when downloading repo archive by downloadrepos above
 PAVICS_SDI_BRANCH="`echo "$PAVICS_SDI_BRANCH" | sed "s@/@-@g"`"
+RAVEN_BRANCH="`echo "$RAVEN_BRANCH" | sed "s@/@-@g"`"
 
 # lowercase VERIFY_SSL string
 VERIFY_SSL="`echo "$VERIFY_SSL" | tr '[:upper:]' '[:lower:]'`"
@@ -28,6 +29,7 @@ fi
 
 ./runtest "notebooks/*.ipynb \
     pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
+# raven-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb
 EXIT_CODE="$?"
 
 


### PR DESCRIPTION
I needed an environment to run the notebooks from raven.

Might as well get everthing ready here and only step left is to enable
those notebooks to be tested by Jenkins.

The raven notebooks will also need some small tweaks to work properly
under Jenkins.