### PR TITLE
Feature/add finch notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # extra repos downloaded
 pavics-sdi-*/
+finch-*/
 raven-*/
 esgf-compute-api-*/
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,8 @@ pipeline {
                description: 'PAVICS host to run notebooks against.', trim: true)
         string(name: 'PAVICS_SDI_BRANCH', defaultValue: 'master',
                description: 'https://github.com/Ouranosinc/pavics-sdi branch to test against.', trim: true)
+        string(name: 'FINCH_BRANCH', defaultValue: 'master',
+               description: 'https://github.com/bird-house/finch branch to test against.', trim: true)
 //        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
 //               description: 'https://github.com/Ouranosinc/raven branch to test against.', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
@@ -50,7 +52,7 @@ Note this is another run, will double the time and no guaranty to have same erro
 
     post {
         always {
-            archiveArtifacts(artifacts: 'environment-export-birdy.yml, conda-list-explicit-birdy.txt, notebooks/*.ipynb, pavics-sdi-*/docs/source/notebooks/*.ipynb, buildout/*.output.ipynb',
+            archiveArtifacts(artifacts: 'environment-export-birdy.yml, conda-list-explicit-birdy.txt, notebooks/*.ipynb, pavics-sdi-*/docs/source/notebooks/*.ipynb, finch-*/docs/source/notebooks/*.ipynb, buildout/*.output.ipynb',
                              fingerprint: true)
         }
 	unsuccessful {  // Run if the current builds status is "Aborted", "Failure" or "Unstable"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190506"
+            image "pavics/workflow-tests:190529"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190506
+FROM pavics/workflow-tests:190529
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -6,10 +6,11 @@ COPY notebooks /notebooks
 
 COPY default_build_params /notebooks
 COPY downloadrepos /notebooks
+COPY binder/reorg-notebooks /notebooks
 
 WORKDIR /notebooks
 
-RUN ./downloadrepos; mv -v pavics-sdi-*/docs/source/notebooks/*.ipynb ./; rm -rfv downloadrepos default_build_params pavics-sdi-*; chown -R jenkins:jenkins .
+RUN ./downloadrepos; ./reorg-notebooks; rm -rfv downloadrepos default_build_params reorg-notebooks; chown -R jenkins:jenkins .
 
 RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mv -v pavics-sdi-*/docs/source/notebooks/*.ipynb ./
+rm -rfv pavics-sdi-*

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -2,3 +2,6 @@
 
 mv -v pavics-sdi-*/docs/source/notebooks/*.ipynb ./
 rm -rfv pavics-sdi-*
+
+mv -v finch-*/docs/source/notebooks/*.ipynb ./
+rm -rfv finch-*

--- a/default_build_params
+++ b/default_build_params
@@ -5,6 +5,13 @@ else
     echo "PAVICS_SDI_BRANCH has been set to '$PAVICS_SDI_BRANCH'"
 fi
 
+if [ -z "$FINCH_BRANCH" ]; then
+    FINCH_BRANCH=master
+    echo "FINCH_BRANCH not set, default to '$FINCH_BRANCH'"
+else
+    echo "FINCH_BRANCH has been set to '$FINCH_BRANCH'"
+fi
+
 if [ -z "$RAVEN_BRANCH" ]; then
     RAVEN_BRANCH=master
     echo "RAVEN_BRANCH not set, default to '$RAVEN_BRANCH'"

--- a/downloadrepos
+++ b/downloadrepos
@@ -9,13 +9,14 @@ downloadrepos() {
 }
 
 downloadouranosrepos() {
+    repo_owner="$1"; shift
     repo_name="$1"; shift
     repo_branch="$1"; shift
     set -x
     # clean up other previously downloaded branches of the same repo as well
     rm -rf ${repo_name}-*
     ls | grep $repo_name
-    downloadrepos https://github.com/Ouranosinc/$repo_name $repo_branch
+    downloadrepos https://github.com/$repo_owner/$repo_name $repo_branch
     ls | grep $repo_name
     set +x
 }
@@ -23,8 +24,9 @@ downloadouranosrepos() {
 . ./default_build_params
 
 if [ -z "$1" ]; then
-    downloadouranosrepos pavics-sdi $PAVICS_SDI_BRANCH
-    downloadouranosrepos raven $RAVEN_BRANCH
+    downloadouranosrepos Ouranosinc pavics-sdi $PAVICS_SDI_BRANCH
+    downloadouranosrepos bird-house finch $FINCH_BRANCH
+    downloadouranosrepos Ouranosinc raven $RAVEN_BRANCH
 else
     set -x
     downloadrepos "$@"

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190506"
+    DOCKER_IMAGE="pavics/workflow-tests:190529"
 fi
 
 UID="`id -u`"

--- a/launchcontainer
+++ b/launchcontainer
@@ -9,7 +9,9 @@ GID="`id -g`"
 
 # launch with current user UID and GID to not have write permission problems
 docker run -it --rm --name birdy \
-    -v `pwd`:`pwd` -u 0:0 -w `pwd` $DOCKER_IMAGE \
+    -v `pwd`:`pwd` -u 0:0 -w `pwd` \
+    $DOCKER_RUN_OPTS \
+    $DOCKER_IMAGE \
     bash -c "groupmod -g $GID jenkins; \
              usermod -u $UID jenkins; \
              echo 'ENV_PATH PATH=/usr/local/envs/birdy/bin:/opt/conda/bin:/usr/local/bin:/usr/bin:/bin' >> /etc/login.defs; \

--- a/launchnotebook
+++ b/launchnotebook
@@ -15,7 +15,9 @@ GID="`id -g`"
 
 # launch with current user UID and GID to not have write permission problems
 docker run --rm --name birdy-notebook \
-    -p $PORT:$PORT -u 0:0 -v `pwd`:`pwd` $DOCKER_IMAGE \
+    -p $PORT:$PORT -u 0:0 -v `pwd`:`pwd` \
+    $DOCKER_RUN_OPTS \
+    $DOCKER_IMAGE \
     bash -c "groupmod -g $GID jenkins; \
              usermod -u $UID jenkins; \
              echo 'ENV_PATH PATH=/usr/local/envs/birdy/bin:/opt/conda/bin:/usr/local/bin:/usr/bin:/bin' >> /etc/login.defs; \

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190506"
+    DOCKER_IMAGE="pavics/workflow-tests:190529"
 fi
 
 UID="`id -u`"

--- a/testall
+++ b/testall
@@ -28,6 +28,9 @@ if [ x"$VERIFY_SSL" = xfalse ]; then
     echo "setting env var DISABLE_VERIFY_SSL for notebooks"
 fi
 
+# presence of this file confuse py.test execution rootdir discovery
+rm -v finch-$FINCH_BRANCH/setup.cfg
+
 ./runtest "notebooks/*.ipynb \
     finch-$FINCH_BRANCH/docs/source/notebooks/*.ipynb \
     pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"

--- a/testall
+++ b/testall
@@ -14,6 +14,7 @@ git clean -fdx
 # for branch name of the format "feature/my_wizbang-feature"
 # github does the same when downloading repo archive by downloadrepos above
 PAVICS_SDI_BRANCH="`echo "$PAVICS_SDI_BRANCH" | sed "s@/@-@g"`"
+FINCH_BRANCH="`echo "$FINCH_BRANCH" | sed "s@/@-@g"`"
 RAVEN_BRANCH="`echo "$RAVEN_BRANCH" | sed "s@/@-@g"`"
 
 # lowercase VERIFY_SSL string
@@ -28,6 +29,7 @@ if [ x"$VERIFY_SSL" = xfalse ]; then
 fi
 
 ./runtest "notebooks/*.ipynb \
+    finch-$FINCH_BRANCH/docs/source/notebooks/*.ipynb \
     pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
 # raven-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb
 EXIT_CODE="$?"


### PR DESCRIPTION
Jenkins now also test Finch notebooks automatically with the usual customization (select different Finch branch) when user manually request a build.

Binder launch will also have Finch notebooks.

The Docker image rebuild was needed to get fix for https://github.com/bird-house/birdy/pull/123 so Finch notebook also pass on my machine which uses self-signed SSL.

Older Jenkins build showing Finch notebook passed against pavics.ouranos.ca: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/feature%252Fadd-finch-notebooks/3/console Can not generate a good build with latest code since Finch on pavics.ouranos.ca is dead again with `{'code': 'ServerBusy', 'locator': '', 'text': 'Maximum number of parallel running processes reached. Please try later.'} `