### PR TITLE
Add ESGF notebooks to Jenkins but not running them yet

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,8 @@ pipeline {
                description: 'https://github.com/bird-house/finch branch to test against.', trim: true)
 //        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
 //               description: 'https://github.com/Ouranosinc/raven branch to test against.', trim: true)
-        string(name: 'ESGF_COMPUTE_API_BRANCH', defaultValue: 'devel',
-               description: 'https://github.com/ESGF/esgf-compute-api branch to test against.', trim: true)
+//        string(name: 'ESGF_COMPUTE_API_BRANCH', defaultValue: 'devel',
+//               description: 'https://github.com/ESGF/esgf-compute-api branch to test against.', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                      description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190620"
+            image "pavics/workflow-tests:190628"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,8 @@ pipeline {
                description: 'https://github.com/bird-house/finch branch to test against.', trim: true)
 //        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
 //               description: 'https://github.com/Ouranosinc/raven branch to test against.', trim: true)
+        string(name: 'ESGF_COMPUTE_API_BRANCH', defaultValue: 'devel',
+               description: 'https://github.com/ESGF/esgf-compute-api branch to test against.', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                      description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,
@@ -52,7 +54,7 @@ Note this is another run, will double the time and no guaranty to have same erro
 
     post {
         always {
-            archiveArtifacts(artifacts: 'notebooks/*.ipynb, pavics-sdi-*/docs/source/notebooks/*.ipynb, finch-*/docs/source/notebooks/*.ipynb, buildout/*.output.ipynb, buildout/env-dump/',
+            archiveArtifacts(artifacts: 'notebooks/*.ipynb, pavics-sdi-*/docs/source/notebooks/*.ipynb, finch-*/docs/source/notebooks/*.ipynb, esgf-compute-api-*/examples/*.ipynb, buildout/*.output.ipynb, buildout/env-dump/',
                              fingerprint: true)
         }
 	unsuccessful {  // Run if the current builds status is "Aborted", "Failure" or "Unstable"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ Note this is another run, will double the time and no guaranty to have same erro
 
     post {
         always {
-            archiveArtifacts(artifacts: 'notebooks/*.ipynb, pavics-sdi-*/docs/source/notebooks/*.ipynb, finch-*/docs/source/notebooks/*.ipynb, esgf-compute-api-*/examples/*.ipynb, buildout/*.output.ipynb, buildout/env-dump/',
+            archiveArtifacts(artifacts: 'notebooks/*.ipynb, pavics-sdi-*/docs/source/notebooks/*.ipynb, finch-*/docs/source/notebooks/*.ipynb, raven-*/docs/source/notebooks/*.ipynb, esgf-compute-api-*/examples/*.ipynb, buildout/*.output.ipynb, buildout/env-dump/',
                              fingerprint: true)
         }
 	unsuccessful {  // Run if the current builds status is "Aborted", "Failure" or "Unstable"

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190620
+FROM pavics/workflow-tests:190628
 
 USER root
 

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -2,6 +2,11 @@
 
 . ./default_build_params
 
+# if name clash, last command wins
+
+mv -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/examples ./esgf-compute-api
+rm -rfv esgf-compute-api-$ESGF_COMPUTE_API_BRANCH
+
 mv -v pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb ./
 rm -rfv pavics-sdi-$PAVICS_SDI_BRANCH
 

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -4,7 +4,7 @@
 
 # if name clash, last command wins
 
-mv -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/examples ./esgf-compute-api
+mv -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/examples ./esgf-compute-api-examples-$ESGF_COMPUTE_API_BRANCH
 rm -rfv esgf-compute-api-$ESGF_COMPUTE_API_BRANCH
 
 mv -v pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb ./

--- a/default_build_params
+++ b/default_build_params
@@ -18,3 +18,10 @@ if [ -z "$RAVEN_BRANCH" ]; then
 else
     echo "RAVEN_BRANCH has been set to '$RAVEN_BRANCH'"
 fi
+
+if [ -z "$ESGF_COMPUTE_API_BRANCH" ]; then
+    ESGF_COMPUTE_API_BRANCH=devel
+    echo "ESGF_COMPUTE_API_BRANCH not set, default to '$ESGF_COMPUTE_API_BRANCH'"
+else
+    echo "ESGF_COMPUTE_API_BRANCH has been set to '$ESGF_COMPUTE_API_BRANCH'"
+fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN python -m ipykernel install --name birdy
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
 # environment.yml above
-# RUN conda install -n birdy -c birdhouse -c conda-forge -c defaults nbdime
+# RUN conda install -n birdy -c birdhouse -c conda-forge -c cdat -c defaults nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 RUN jupyter lab build

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -3,6 +3,7 @@ name: birdy
 channels:
   - birdhouse
   - conda-forge
+  - cdat
   - defaults
 dependencies:
   - matplotlib
@@ -14,6 +15,11 @@ dependencies:
   - cartopy
   - descartes
   - xclim
+  # for esgf notebooks
+  - esgf-compute-api
+  - cdms2
+  - vcs
+  - mesalib
   # tests
   - pytest
   - nbval

--- a/downloadrepos
+++ b/downloadrepos
@@ -8,7 +8,7 @@ downloadrepos() {
         $github_repo/archive/${branch}.tar.gz | tar xz
 }
 
-downloadouranosrepos() {
+downloadgithubrepos() {
     repo_owner="$1"; shift
     repo_name="$1"; shift
     repo_branch="$1"; shift
@@ -24,9 +24,10 @@ downloadouranosrepos() {
 . ./default_build_params
 
 if [ -z "$1" ]; then
-    downloadouranosrepos Ouranosinc pavics-sdi $PAVICS_SDI_BRANCH
-    downloadouranosrepos bird-house finch $FINCH_BRANCH
-    downloadouranosrepos Ouranosinc raven $RAVEN_BRANCH
+    downloadgithubrepos Ouranosinc pavics-sdi $PAVICS_SDI_BRANCH
+    downloadgithubrepos bird-house finch $FINCH_BRANCH
+    downloadgithubrepos Ouranosinc raven $RAVEN_BRANCH
+    downloadgithubrepos ESGF esgf-compute-api $ESGF_COMPUTE_API_BRANCH
 else
     set -x
     downloadrepos "$@"

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190620"
+    DOCKER_IMAGE="pavics/workflow-tests:190628"
 fi
 
 UID="`id -u`"

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190620"
+    DOCKER_IMAGE="pavics/workflow-tests:190628"
 fi
 
 UID="`id -u`"

--- a/runtest
+++ b/runtest
@@ -38,6 +38,10 @@ if [ x"$SAVE_RESULTING_NOTEBOOK" = xtrue ]; then
     for nb in $NOTEBOOKS; do
         filename="`basename "$nb"`"
         filename="`echo "$filename" | sed "s/.ipynb$//"`"  # remove .ipynb ext
+        if [ -e "buildout/${filename}.output.ipynb" ]; then
+            # prevent name clash
+            filename="${filename}_`date '+%s'`"
+        fi
         jupyter nbconvert --to notebook --execute \
             --ExecutePreprocessor.timeout=60 --allow-errors \
             --output-dir buildout --output ${filename}.output.ipynb $nb

--- a/runtest
+++ b/runtest
@@ -44,7 +44,7 @@ if [ x"$SAVE_RESULTING_NOTEBOOK" = xtrue ]; then
         fi
         jupyter nbconvert --to notebook --execute \
             --ExecutePreprocessor.timeout=60 --allow-errors \
-            --output-dir buildout --output ${filename}.output.ipynb $nb
+            --output-dir buildout --output "${filename}.output.ipynb" "$nb"
     done
 fi
 

--- a/testall
+++ b/testall
@@ -38,8 +38,8 @@ rm -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/tox.ini
 # last notebooks higher chance for name clash
 ./runtest "notebooks/*.ipynb \
     finch-$FINCH_BRANCH/docs/source/notebooks/*.ipynb \
-    pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb \
-    esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
+    pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
+# esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
 # raven-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb
 EXIT_CODE="$?"
 

--- a/testall
+++ b/testall
@@ -16,6 +16,7 @@ git clean -fdx
 PAVICS_SDI_BRANCH="`echo "$PAVICS_SDI_BRANCH" | sed "s@/@-@g"`"
 FINCH_BRANCH="`echo "$FINCH_BRANCH" | sed "s@/@-@g"`"
 RAVEN_BRANCH="`echo "$RAVEN_BRANCH" | sed "s@/@-@g"`"
+ESGF_COMPUTE_API_BRANCH="`echo "$ESGF_COMPUTE_API_BRANCH" | sed "s@/@-@g"`"
 
 # lowercase VERIFY_SSL string
 VERIFY_SSL="`echo "$VERIFY_SSL" | tr '[:upper:]' '[:lower:]'`"
@@ -28,12 +29,17 @@ if [ x"$VERIFY_SSL" = xfalse ]; then
     echo "setting env var DISABLE_VERIFY_SSL for notebooks"
 fi
 
-# presence of this file confuse py.test execution rootdir discovery
+# presence of setup.cfg, tox.ini files confuse py.test execution rootdir discovery
 rm -v finch-$FINCH_BRANCH/setup.cfg
+rm -v raven-$RAVEN_BRANCH/setup.cfg
+rm -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/setup.cfg
+rm -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/tox.ini
 
+# last notebooks higher chance for name clash
 ./runtest "notebooks/*.ipynb \
     finch-$FINCH_BRANCH/docs/source/notebooks/*.ipynb \
-    pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
+    pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb \
+    esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
 # raven-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb
 EXIT_CODE="$?"
 


### PR DESCRIPTION
Will run them once they all pass, part of https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/13

The ESGF branch is devel and not the usual master because that's what @huard asked.

This PR will lay down the all the ground work to run ESGF notebooks:
* download the ESGF notebooks in Jenkins and also for the auto notebooks deployment to PAVICS and Binder
* publish new Docker image that is able to run ESGF notebooks
* gracefully handle notebook name clash since ESGF notebooks filename are very generic

New Docker image with ability to run ESGF notebooks can then be deployed to our PAVICS instance so we have a public env for everyone to reproduce any possible errors / test fixes.

Few minor fixes to also be ready for Raven notebooks.

Test Jupyter env able to run ESGF notebooks: https://lvu.ouranos.ca/jupyter/user/public/lab/tree/tutorial-notebooks/esgf-compute-api-examples-devel
