### PR TITLE
Refresh Jupyter Server Image for PAVICS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190708"
+            image "pavics/workflow-tests:190812"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190708
+FROM pavics/workflow-tests:190812
 
 USER root
 

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190708"
+    DOCKER_IMAGE="pavics/workflow-tests:190812"
 fi
 
 UID="`id -u`"

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190708"
+    DOCKER_IMAGE="pavics/workflow-tests:190812"
 fi
 
 UID="`id -u`"


### PR DESCRIPTION
Same image used for Jenkins testing as well, no new errors on Jenkins http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/refresh-docker-image/2/console

Noticeable changes:

```
<     - xclim==0.10.4b0
>     - xclim==0.10.7b0  

<     - dask==2.1.0
>     - dask==2.2.0

<   - notebook=5.7.8=py36_1
>   - notebook=6.0.0=py36_0

<   - jupyter_server=0.0.5=py36_0
>   - jupyter_server=0.1.1=py36_0

<   - gitpython=2.1.11=py_0
>   - gitpython=3.0.0=py_0

# note it's a downgrade !
<   - openblas=0.3.6=h6e990d7_4
>   - openblas=0.3.3=h9ac9557_1001

# weird that libopenblas is not downgraded consistently
<   - libopenblas=0.3.6=h6e990d7_4
>   - libopenblas=0.3.6=h5a2b251_1

# downgrade !
<   - scipy=1.3.0=py36h921218d_0
>   - scipy=1.2.1=py36_blas_openblash1522bff_0


```