### PR TITLE
Add gdal (osgeo) to docker image for new notebooks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190816"
+            image "pavics/workflow-tests:190819"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190812"
+            image "pavics/workflow-tests:190816"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190816
+FROM pavics/workflow-tests:190819
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190812
+FROM pavics/workflow-tests:190816
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - cartopy
   - descartes
   - rasterio
+  - gdal  # for osgeo
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
   # - xclim

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - descartes
   - rasterio
   - gdal  # for osgeo
+  - tiledb=1.6.0  # pinned version for gdal-3.0.1, remove for future gdal
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
   # - xclim

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190816"
+    DOCKER_IMAGE="pavics/workflow-tests:190819"
 fi
 
 UID="`id -u`"

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190812"
+    DOCKER_IMAGE="pavics/workflow-tests:190816"
 fi
 
 UID="`id -u`"

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190812"
+    DOCKER_IMAGE="pavics/workflow-tests:190816"
 fi
 
 UID="`id -u`"

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190816"
+    DOCKER_IMAGE="pavics/workflow-tests:190819"
 fi
 
 UID="`id -u`"


### PR DESCRIPTION
Jenkins build http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/add-module-osgeo-to-docker-image-for-new-notebooks/2/consoleFull no more `ImportError`.

We got `gdal-3.0.1`.

It's odd that I do not see new birdy version.  I thought Carlsten did it.