### PR TITLE
New Jenkine env / Jupyter docker with new birdy and dropped birdhouse channel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190830"
+            image "pavics/workflow-tests:190830.1"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190822"
+            image "pavics/workflow-tests:190830"
             label 'linux && docker'
         }
     }

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ By using the exact same Docker container as the one that Jenkins will use, you
 will be guarantied that if a notebook runs locally, it will also run
 successfully on Jenkins.
 
-Therefore we do not need to pin any versions in the conda `environment.yml`
-file since the built docker image provided us with pinned version for
-reproducibility.
+Therefore we do not need to pin any versions in the conda
+[`environment.yml`](docker/environment.yml) file since the built docker image
+provided us with pinned version for reproducibility.
 
 To encourage more notebooks written/contribution, which means more
 documentations and more tests, it is easy to add new notebooks and the test
@@ -133,8 +133,8 @@ docker stop birdy-notebook  # the container created by launchnotebook
 
 ## Releasing a new Docker image
 
-Use the script `releasedocker <old_ver> <new_ver>`, example: `releasedocker
-190311 190312`.
+Use the script [`releasedocker`](releasedocker)` <old_ver> <new_ver>`, example:
+`releasedocker 190311 190312`.
 
 This script will commit, tag and push a new release.  You need write access to
 the repo when using this script.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ By using the exact same Docker container as the one that Jenkins will use, you
 will be guarantied that if a notebook runs locally, it will also run
 successfully on Jenkins.
 
-Therefore we do not need to pin any versions in the conda environment.yml file
-since the built docker image provided us with pinned version for
+Therefore we do not need to pin any versions in the conda `environment.yml`
+file since the built docker image provided us with pinned version for
 reproducibility.
 
 To encourage more notebooks written/contribution, which means more
@@ -133,23 +133,12 @@ docker stop birdy-notebook  # the container created by launchnotebook
 
 ## Releasing a new Docker image
 
-All the steps below can be automated by using the script `releasedocker
-<old_ver> <new_ver>`, example: `releasedocker 190311 190312`.
+Use the script `releasedocker <old_ver> <new_ver>`, example: `releasedocker
+190311 190312`.
 
-Update `Jenkinsfile`, `launchcontainer`, `launchnotebook` with the soon to
-build `pavics/workflow-tests` image tag.
+This script will commit, tag and push a new release.  You need write access to
+the repo when using this script.
 
-Tag with `docker-YYMMDD` and push and the Docker image tag will be the `YYMMDD` part.
-
-Example:
-```
-$EDITOR Jenkinsfile launchcontainer launchnotebook
-# update to pavics/workflow-tests:190311
-git ci -am "update to use image pavics/workflow-tests:190311"
-git tag docker-190311
-git push
-git push --tags
-```
-
-Then Docker Hub will build automatically and eventually we have a new image
-[`pavics/workflow-tests:190311`](https://hub.docker.com/r/pavics/workflow-tests).
+Then Docker Hub will build automatically the new tag and eventually we have a
+new image, example:
+[`pavics/workflow-tests:190312`](https://hub.docker.com/r/pavics/workflow-tests/tags).

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190830
+FROM pavics/workflow-tests:190830.1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190822
+FROM pavics/workflow-tests:190830
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN python -m ipykernel install --name birdy
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
 # environment.yml above
-# RUN conda install -n birdy -c birdhouse -c conda-forge -c cdat -c defaults nbdime
+# RUN conda install -n birdy -c conda-forge -c cdat -c defaults nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 RUN jupyter lab build

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - descartes
   - rasterio
   - gdal  # for osgeo
-  - tiledb=1.6.0  # pinned version for gdal-3.0.1, remove for future gdal
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
   # - xclim

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -1,7 +1,6 @@
 # conda env create -f environment.yml
 name: birdy
 channels:
-  - birdhouse
   - conda-forge
   - cdat
   - defaults
@@ -9,7 +8,7 @@ dependencies:
   - matplotlib
   - xarray
   - numpy
-  - birdhouse-birdy
+  - birdy
   - netcdf4
   - pydap
   - cartopy

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190822"
+    DOCKER_IMAGE="pavics/workflow-tests:190830"
 fi
 
 UID="`id -u`"

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190830"
+    DOCKER_IMAGE="pavics/workflow-tests:190830.1"
 fi
 
 UID="`id -u`"

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190830"
+    DOCKER_IMAGE="pavics/workflow-tests:190830.1"
 fi
 
 UID="`id -u`"

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190822"
+    DOCKER_IMAGE="pavics/workflow-tests:190830"
 fi
 
 UID="`id -u`"

--- a/releasedocker
+++ b/releasedocker
@@ -17,7 +17,7 @@ git add launchcontainer launchnotebook Jenkinsfile binder/Dockerfile
 git st -v
 echo "Looks good to commit? (Ctrl-C to abort)"; read a
 
-git ci -m "update to use image pavics/workflow-tests:$NEW_VER"
+git ci -m "release: update to use image pavics/workflow-tests:$NEW_VER"
 git show
 echo "Looks good to tag and push? (Ctrl-C to abort)"; read a
 


### PR DESCRIPTION
Changes hightlight:

Updated:
```
<   - birdhouse-birdy=0.6.2=py_0
>   - birdy=v0.6.5=py_0

<   - owslib=0.17.1b4=py_0  # was from birdhouse channel
>   - owslib=0.18.0=py_0  # now from conda-forge
```

Removed:
```
<   - owslib-esgfwps=0.1.0=py_0  # birdy dropped this dependency I think
```

Full conda env diff:  [env-diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/3561311/env-diff.txt)

New conda env export:  [190830.1.env.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/3561316/190830.1.env.txt)

Jupyter test env deployed: https://lvupavics.ouranos.ca/jupyter
