### PR TITLE
Update Jupyter docker image for new and updated packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:190830.1"
+            image "pavics/workflow-tests:191106"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:190830.1
+FROM pavics/workflow-tests:191106
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -46,3 +46,4 @@ dependencies:
     - xclim
     # visual debugger for Jupyter Notebook, not working with JupyterLab at this moment
     - pixiedust
+    - -e git+https://github.com/Ouranosinc/requests-magpie@master#egg=request-magpie

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - descartes
   - rasterio
   - gdal  # for osgeo
+  - geopandas
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
   # - xclim

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190830.1"
+    DOCKER_IMAGE="pavics/workflow-tests:191106"
 fi
 
 UID="`id -u`"

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:190830.1"
+    DOCKER_IMAGE="pavics/workflow-tests:191106"
 fi
 
 UID="`id -u`"


### PR DESCRIPTION
Add geopandas and the new request-magpie so notebooks will work with the coming Twitcher/Magpie upgrade (needed to test the Twitcher/Magpie upgrade).

Noticeable changes:

```diff
+  - geopandas=0.6.1=py_1 

request-magpie do not show up anywhere :(

-  - python=3.6.7=h357f687_1005
+  - python=3.7.3=h33d41f4_1

-  - xarray=0.12.3=py_0 
+    - xarray==0.13.0

-    - dask==2.3.0                                                                                                                                
+    - dask==2.6.0

-    - xclim==0.10.8b0                                                                                                                            
+    - xclim==0.11.2
```

Quite a few packages moved from Conda to Pip, ex: xarray, pyproj

Full diff: [diff-190830.1-191106.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/3817053/diff-190830.1-191106.diff.txt)

Full new conda env export: [191106-environment-export-birdy.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/3817056/191106-environment-export-birdy.yml.txt)

Jenkins run no new error: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/update-docker-image-for-new-and-updated-packages/5/console
