### PR TITLE
docker: use requests-magpie from pypi

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -46,4 +46,4 @@ dependencies:
     - xclim
     # visual debugger for Jupyter Notebook, not working with JupyterLab at this moment
     - pixiedust
-    - -e git+https://github.com/Ouranosinc/requests-magpie@master#egg=requests-magpie
+    - requests-magpie


### PR DESCRIPTION
Because pypi release now exists and because `conda environment export`
do not show anything install from source so we are losing traceability.

Before:

  $ docker run --rm --name testconda -u 0  -it --entrypoint bash pavics/workflow-tests:191106
  root@e159d1f12a2e:/# conda env export -n birdy |grep request
    - requests=2.22.0=py37_1

After

  docker run --rm --name testconda -u 0  -it --entrypoint bash local-build-image
  root@170dc125ffc3:/# conda env export -n birdy |grep request
    - requests=2.22.0=py37_1
      - requests-magpie==0.1.1