### PR TITLE
notebooks: add regex for print of wps response log

### DIFF
--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -49,3 +49,7 @@ replace: Meteorological Service of Canada Geospatial Web Services VERSION
 [raven_nb_diagnostics_print]
 regex: HYDROGRAPH,/tmp/pywps_process_[a-z0-9_]{8}/.+.nc,
 replace: HYDROGRAPH,/tmp/pywps_process_RANDOM/input.nc,
+
+[print_wps_resp_log]
+regex: 100%\sDone\s|\s+\d.\d\d?s
+replace: 100% Done |  1.0s


### PR DESCRIPTION
To avoid intermittent failure like below due to server performance variation.
```
  _________ finch-master/docs/source/notebooks/finch-usage.ipynb::Cell 9 _________
  Notebook cell execution failed
  Cell 9: Cell outputs differ

  Input:
  print(log)

  Traceback:
   mismatch 'stdout'

  assert reference_output == test_output failed:

   'Processing s...cessfully\n\n' == 'Processing s...cessfully\n\n'
   Skipping 281 identical leading characters in diff, use -v to show
   - Done |  1.0s
   ?           ^
   + Done |  1.1s
   ?           ^
     Processing finished successfully
```

Jenkins run: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/more-regex-to-avoid-intermittent-failure/1/console