### PR TITLE
jenkins: support downloading repos from a fork

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,13 +14,21 @@ pipeline {
         string(name: 'PAVICS_HOST', defaultValue: 'pavics.ouranos.ca',
                description: 'PAVICS host to run notebooks against.', trim: true)
         string(name: 'PAVICS_SDI_BRANCH', defaultValue: 'master',
-               description: 'https://github.com/Ouranosinc/pavics-sdi branch to test against.', trim: true)
+               description: 'PAVICS_SDI_REPO branch to test against.', trim: true)
+        string(name: 'PAVICS_SDI_REPO', defaultValue: 'Ouranosinc/pavics-sdi',
+               description: 'https://github.com/Ouranosinc/pavics-sdi repo or fork to test against.', trim: true)
         string(name: 'FINCH_BRANCH', defaultValue: 'master',
-               description: 'https://github.com/bird-house/finch branch to test against.', trim: true)
+               description: 'FINCH_REPO branch to test against.', trim: true)
+        string(name: 'FINCH_REPO', defaultValue: 'bird-house/finch',
+               description: 'https://github.com/bird-house/finch repo or fork to test against.', trim: true)
 //        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
-//               description: 'https://github.com/Ouranosinc/raven branch to test against.', trim: true)
+//               description: 'RAVEN_REPO branch to test against.', trim: true)
+//        string(name: 'RAVEN_REPO', defaultValue: 'Ouranosinc/raven',
+//               description: 'https://github.com/Ouranosinc/raven repo or fork to test against.', trim: true)
 //        string(name: 'ESGF_COMPUTE_API_BRANCH', defaultValue: 'devel',
-//               description: 'https://github.com/ESGF/esgf-compute-api branch to test against.', trim: true)
+//               description: 'ESGF_COMPUTE_API_REPO branch to test against.', trim: true)
+//        string(name: 'ESGF_COMPUTE_API_REPO', defaultValue: 'ESGF/esgf-compute-api',
+//               description: 'https://github.com/ESGF/esgf-compute-api repo or fork to test against.', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                      description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 . ./default_build_params
+# no need to calculate each REPO_NAME since Binder only uses defaults
 
 # if name clash, last command wins
 

--- a/default_build_params
+++ b/default_build_params
@@ -5,11 +5,25 @@ else
     echo "PAVICS_SDI_BRANCH has been set to '$PAVICS_SDI_BRANCH'"
 fi
 
+if [ -z "$PAVICS_SDI_REPO" ]; then
+    PAVICS_SDI_REPO='Ouranosinc/pavics-sdi'
+    echo "PAVICS_SDI_REPO not set, default to '$PAVICS_SDI_REPO'"
+else
+    echo "PAVICS_SDI_REPO has been set to '$PAVICS_SDI_REPO'"
+fi
+
 if [ -z "$FINCH_BRANCH" ]; then
     FINCH_BRANCH=master
     echo "FINCH_BRANCH not set, default to '$FINCH_BRANCH'"
 else
     echo "FINCH_BRANCH has been set to '$FINCH_BRANCH'"
+fi
+
+if [ -z "$FINCH_REPO" ]; then
+    FINCH_REPO='bird-house/finch'
+    echo "FINCH_REPO not set, default to '$FINCH_REPO'"
+else
+    echo "FINCH_REPO has been set to '$FINCH_REPO'"
 fi
 
 if [ -z "$RAVEN_BRANCH" ]; then
@@ -19,9 +33,23 @@ else
     echo "RAVEN_BRANCH has been set to '$RAVEN_BRANCH'"
 fi
 
+if [ -z "$RAVEN_REPO" ]; then
+    RAVEN_REPO='Ouranosinc/raven'
+    echo "RAVEN_REPO not set, default to '$RAVEN_REPO'"
+else
+    echo "RAVEN_REPO has been set to '$RAVEN_REPO'"
+fi
+
 if [ -z "$ESGF_COMPUTE_API_BRANCH" ]; then
     ESGF_COMPUTE_API_BRANCH=devel
     echo "ESGF_COMPUTE_API_BRANCH not set, default to '$ESGF_COMPUTE_API_BRANCH'"
 else
     echo "ESGF_COMPUTE_API_BRANCH has been set to '$ESGF_COMPUTE_API_BRANCH'"
+fi
+
+if [ -z "$ESGF_COMPUTE_API_REPO" ]; then
+    ESGF_COMPUTE_API_REPO='ESGF/esgf-compute-api'
+    echo "ESGF_COMPUTE_API_REPO not set, default to '$ESGF_COMPUTE_API_REPO'"
+else
+    echo "ESGF_COMPUTE_API_REPO has been set to '$ESGF_COMPUTE_API_REPO'"
 fi

--- a/downloadrepos
+++ b/downloadrepos
@@ -9,8 +9,9 @@ downloadrepos() {
 }
 
 downloadgithubrepos() {
-    repo_owner="$1"; shift
-    repo_name="$1"; shift
+    owner_and_repo_name="$1"; shift
+    repo_owner="`echo "$owner_and_repo_name" | sed "s@/.*\\$@@g"`"
+    repo_name="`echo "$owner_and_repo_name" | sed "s@^.*/@@g"`"
     repo_branch="$1"; shift
     set -x
     # clean up other previously downloaded branches of the same repo as well
@@ -24,10 +25,10 @@ downloadgithubrepos() {
 . ./default_build_params
 
 if [ -z "$1" ]; then
-    downloadgithubrepos Ouranosinc pavics-sdi $PAVICS_SDI_BRANCH
-    downloadgithubrepos bird-house finch $FINCH_BRANCH
-    downloadgithubrepos Ouranosinc raven $RAVEN_BRANCH
-    downloadgithubrepos ESGF esgf-compute-api $ESGF_COMPUTE_API_BRANCH
+    downloadgithubrepos $PAVICS_SDI_REPO $PAVICS_SDI_BRANCH
+    downloadgithubrepos $FINCH_REPO $FINCH_BRANCH
+    downloadgithubrepos $RAVEN_REPO $RAVEN_BRANCH
+    downloadgithubrepos $ESGF_COMPUTE_API_REPO $ESGF_COMPUTE_API_BRANCH
 else
     set -x
     downloadrepos "$@"

--- a/testall
+++ b/testall
@@ -14,9 +14,13 @@ git clean -fdx
 # for branch name of the format "feature/my_wizbang-feature"
 # github does the same when downloading repo archive by downloadrepos above
 PAVICS_SDI_BRANCH="`echo "$PAVICS_SDI_BRANCH" | sed "s@/@-@g"`"
+PAVICS_SDI_REPO_NAME="`echo "$PAVICS_SDI_REPO" | sed "s@^.*/@@g"`"
 FINCH_BRANCH="`echo "$FINCH_BRANCH" | sed "s@/@-@g"`"
+FINCH_REPO_NAME="`echo "$FINCH_REPO" | sed "s@^.*/@@g"`"
 RAVEN_BRANCH="`echo "$RAVEN_BRANCH" | sed "s@/@-@g"`"
+RAVEN_REPO_NAME="`echo "$RAVEN_REPO" | sed "s@^.*/@@g"`"
 ESGF_COMPUTE_API_BRANCH="`echo "$ESGF_COMPUTE_API_BRANCH" | sed "s@/@-@g"`"
+ESGF_COMPUTE_API_REPO_NAME="`echo "$ESGF_COMPUTE_API_REPO" | sed "s@^.*/@@g"`"
 
 # lowercase VERIFY_SSL string
 VERIFY_SSL="`echo "$VERIFY_SSL" | tr '[:upper:]' '[:lower:]'`"
@@ -30,17 +34,17 @@ if [ x"$VERIFY_SSL" = xfalse ]; then
 fi
 
 # presence of setup.cfg, tox.ini files confuse py.test execution rootdir discovery
-rm -v finch-$FINCH_BRANCH/setup.cfg
-rm -v raven-$RAVEN_BRANCH/setup.cfg
-rm -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/setup.cfg
-rm -v esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/tox.ini
+rm -v $FINCH_REPO_NAME-$FINCH_BRANCH/setup.cfg
+rm -v $RAVEN_REPO_NAME-$RAVEN_BRANCH/setup.cfg
+rm -v $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/setup.cfg
+rm -v $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/tox.ini
 
 # last notebooks higher chance for name clash
 ./runtest "notebooks/*.ipynb \
-    finch-$FINCH_BRANCH/docs/source/notebooks/*.ipynb \
-    pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
-# esgf-compute-api-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
-# raven-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb
+    $FINCH_REPO_NAME-$FINCH_BRANCH/docs/source/notebooks/*.ipynb \
+    $PAVICS_SDI_REPO_NAME-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
+# $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
+# $RAVEN_REPO_NAME-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb
 EXIT_CODE="$?"
 
 


### PR DESCRIPTION
Example: download from https://github.com/tlvu/esgf-compute-api instead of
https://github.com/ESGF/esgf-compute-api

For each repo, the user can now specify the branch and the
owner/repo-name on github.

Only limittation is that repo has to be hosted on github.  Everything
else can be customized at Jenkins build request time.

Was needed to test my attempt to fix the ESGF notebooks in this PR https://github.com/ESGF/esgf-compute-api/pull/64

Here is how the new build request page looks like:

![2019-11-25-164934_1329x691_scrot](https://user-images.githubusercontent.com/11966697/69580959-99a47800-0fa3-11ea-99f0-99efec63c307.png)

Edit:

* add screenshot of "before"

![2019-11-25-165238_1328x629_scrot](https://user-images.githubusercontent.com/11966697/69581173-10417580-0fa4-11ea-95f5-e9dbfa6d9d8a.png)

