### PR TITLE
Use new env var to customize scheduled trigger and defaut pavics host, also feature toogle external repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 String cron_only_on_master = ""
 if (env.IS_PROD == "true" || env.ENABLE_SCHEDULED_TRIGGER == "true") {
-    cron_only_on_master = env.BRANCH_NAME == "master" ? "@midnight" : ""
+    cron_only_on_master = env.BRANCH_NAME == "master" || env.GIT_BRANCH == 'origin/master' ? "@midnight" : ""
 }
 
 String default_pavics_host = env.DEFAULT_PAVICS_HOST != null ? env.DEFAULT_PAVICS_HOST : "pavics.ouranos.ca"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,8 @@ Note this is another run, will double the time and no guaranty to have same erro
         timestamps()
         timeout(time: 1, unit: 'HOURS')
         // trying to keep 2 months worth of history with buffer for manual
-        // build trigger
-        buildDiscarder(logRotator(numToKeepStr: '100'))
+        // build trigger on failed builds or manual test after each production
+        // deployment or test deployment
+        buildDiscarder(logRotator(numToKeepStr: '200'))
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,8 @@ if (env.IS_PROD == "true" || env.ENABLE_SCHEDULED_TRIGGER == "true") {
     cron_only_on_master = env.BRANCH_NAME == "master" ? "@midnight" : ""
 }
 
+String default_pavics_host = env.DEFAULT_PAVICS_HOST != null ? env.DEFAULT_PAVICS_HOST : "pavics.ouranos.ca"
+
 pipeline {
     // Guide book on Jenkins declarative pipelines
     // https://jenkins.io/doc/book/pipeline/syntax/
@@ -14,7 +16,7 @@ pipeline {
     }
 
     parameters {
-        string(name: 'PAVICS_HOST', defaultValue: 'pavics.ouranos.ca',
+        string(name: 'PAVICS_HOST', defaultValue: default_pavics_host,
                description: 'PAVICS host to run notebooks against.', trim: true)
         string(name: 'PAVICS_SDI_BRANCH', defaultValue: 'master',
                description: 'PAVICS_SDI_REPO branch to test against.', trim: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
-String cron_only_on_master = env.BRANCH_NAME == "master" ? "@midnight" : ""
+String cron_only_on_master = ""
+if (env.IS_PROD == "true" || env.ENABLE_SCHEDULED_TRIGGER == "true") {
+    cron_only_on_master = env.BRANCH_NAME == "master" ? "@midnight" : ""
+}
 
 pipeline {
     // Guide book on Jenkins declarative pipelines

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,9 @@ Note this is another run, will double the time and no guaranty to have same erro
                                           passwordVariable: 'ESGF_AUTH_PASSWORD',
                                           usernameVariable: 'ESGF_AUTH_USERNAME'),
                          string(credentialsId: 'esgf_auth_token',
-                                variable: 'ESGF_AUTH_TOKEN')
+                                variable: 'ESGF_AUTH_TOKEN'),  // Kept old env var name for backward compat
+                         string(credentialsId: 'esgf_auth_token',
+                                variable: 'COMPUTE_TOKEN')  // ESGF expect this env var name
                          ]) {
                         sh("VERIFY_SSL=${params.VERIFY_SSL} \
                             SAVE_RESULTING_NOTEBOOK=${params.SAVE_RESULTING_NOTEBOOK} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,22 +18,30 @@ pipeline {
     parameters {
         string(name: 'PAVICS_HOST', defaultValue: default_pavics_host,
                description: 'PAVICS host to run notebooks against.', trim: true)
+        booleanParam(name: 'TEST_PAVICS_SDI_REPO', defaultValue: true,
+                     description: 'Check the box to test pavics-sdi repo.')
         string(name: 'PAVICS_SDI_BRANCH', defaultValue: 'master',
                description: 'PAVICS_SDI_REPO branch to test against.', trim: true)
         string(name: 'PAVICS_SDI_REPO', defaultValue: 'Ouranosinc/pavics-sdi',
                description: 'https://github.com/Ouranosinc/pavics-sdi repo or fork to test against.', trim: true)
+        booleanParam(name: 'TEST_FINCH_REPO', defaultValue: true,
+                     description: 'Check the box to test finch repo.')
         string(name: 'FINCH_BRANCH', defaultValue: 'master',
                description: 'FINCH_REPO branch to test against.', trim: true)
         string(name: 'FINCH_REPO', defaultValue: 'bird-house/finch',
                description: 'https://github.com/bird-house/finch repo or fork to test against.', trim: true)
-//        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
-//               description: 'RAVEN_REPO branch to test against.', trim: true)
-//        string(name: 'RAVEN_REPO', defaultValue: 'Ouranosinc/raven',
-//               description: 'https://github.com/Ouranosinc/raven repo or fork to test against.', trim: true)
-//        string(name: 'ESGF_COMPUTE_API_BRANCH', defaultValue: 'devel',
-//               description: 'ESGF_COMPUTE_API_REPO branch to test against.', trim: true)
-//        string(name: 'ESGF_COMPUTE_API_REPO', defaultValue: 'ESGF/esgf-compute-api',
-//               description: 'https://github.com/ESGF/esgf-compute-api repo or fork to test against.', trim: true)
+        booleanParam(name: 'TEST_RAVEN_REPO', defaultValue: false,
+                     description: 'Check the box to test raven repo.')
+        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
+               description: 'RAVEN_REPO branch to test against.', trim: true)
+        string(name: 'RAVEN_REPO', defaultValue: 'Ouranosinc/raven',
+               description: 'https://github.com/Ouranosinc/raven repo or fork to test against.', trim: true)
+        booleanParam(name: 'TEST_ESGF_COMPUTE_API_REPO', defaultValue: false,
+                     description: 'Check the box to test esgf-compute-api repo.')
+        string(name: 'ESGF_COMPUTE_API_BRANCH', defaultValue: 'devel',
+               description: 'ESGF_COMPUTE_API_REPO branch to test against.', trim: true)
+        string(name: 'ESGF_COMPUTE_API_REPO', defaultValue: 'ESGF/esgf-compute-api',
+               description: 'https://github.com/ESGF/esgf-compute-api repo or fork to test against.', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                      description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,

--- a/default_build_params
+++ b/default_build_params
@@ -1,3 +1,10 @@
+if [ -z "$TEST_PAVICS_SDI_REPO" ]; then
+    TEST_PAVICS_SDI_REPO=true
+    echo "TEST_PAVICS_SDI_REPO not set, default to '$TEST_PAVICS_SDI_REPO'"
+else
+    echo "TEST_PAVICS_SDI_REPO has been set to '$TEST_PAVICS_SDI_REPO'"
+fi
+
 if [ -z "$PAVICS_SDI_BRANCH" ]; then
     PAVICS_SDI_BRANCH=master
     echo "PAVICS_SDI_BRANCH not set, default to '$PAVICS_SDI_BRANCH'"
@@ -10,6 +17,13 @@ if [ -z "$PAVICS_SDI_REPO" ]; then
     echo "PAVICS_SDI_REPO not set, default to '$PAVICS_SDI_REPO'"
 else
     echo "PAVICS_SDI_REPO has been set to '$PAVICS_SDI_REPO'"
+fi
+
+if [ -z "$TEST_FINCH_REPO" ]; then
+    TEST_FINCH_REPO=true
+    echo "TEST_FINCH_REPO not set, default to '$TEST_FINCH_REPO'"
+else
+    echo "TEST_FINCH_REPO has been set to '$TEST_FINCH_REPO'"
 fi
 
 if [ -z "$FINCH_BRANCH" ]; then
@@ -26,6 +40,13 @@ else
     echo "FINCH_REPO has been set to '$FINCH_REPO'"
 fi
 
+if [ -z "$TEST_RAVEN_REPO" ]; then
+    TEST_RAVEN_REPO=false
+    echo "TEST_RAVEN_REPO not set, default to '$TEST_RAVEN_REPO'"
+else
+    echo "TEST_RAVEN_REPO has been set to '$TEST_RAVEN_REPO'"
+fi
+
 if [ -z "$RAVEN_BRANCH" ]; then
     RAVEN_BRANCH=master
     echo "RAVEN_BRANCH not set, default to '$RAVEN_BRANCH'"
@@ -38,6 +59,13 @@ if [ -z "$RAVEN_REPO" ]; then
     echo "RAVEN_REPO not set, default to '$RAVEN_REPO'"
 else
     echo "RAVEN_REPO has been set to '$RAVEN_REPO'"
+fi
+
+if [ -z "$TEST_ESGF_COMPUTE_API_REPO" ]; then
+    TEST_ESGF_COMPUTE_API_REPO=false
+    echo "TEST_ESGF_COMPUTE_API_REPO not set, default to '$TEST_ESGF_COMPUTE_API_REPO'"
+else
+    echo "TEST_ESGF_COMPUTE_API_REPO has been set to '$TEST_ESGF_COMPUTE_API_REPO'"
 fi
 
 if [ -z "$ESGF_COMPUTE_API_BRANCH" ]; then

--- a/runtest
+++ b/runtest
@@ -7,6 +7,13 @@ fi
 
 set -x
 
+if [ -n "$FORCE_PAVICS_HOST" ]; then
+    # jenkins work-around for envinject incompatibility with pipeline
+    echo "FORCE_PAVICS_HOST='$FORCE_PAVICS_HOST'"
+    echo "Overriding PAVICS_HOST with value from FORCE_PAVICS_HOST"
+    PAVICS_HOST="$FORCE_PAVICS_HOST"
+fi
+
 if [ ! -z "$PAVICS_HOST" ]; then
     echo "Will run notebooks against $PAVICS_HOST"
     sed -i "s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS

--- a/testall
+++ b/testall
@@ -39,12 +39,28 @@ rm -v $RAVEN_REPO_NAME-$RAVEN_BRANCH/setup.cfg
 rm -v $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/setup.cfg
 rm -v $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/tox.ini
 
+# lowercase
+TEST_PAVICS_SDI_REPO="`echo "$TEST_PAVICS_SDI_REPO" | tr '[:upper:]' '[:lower:]'`"
+TEST_FINCH_REPO="`echo "$TEST_FINCH_REPO" | tr '[:upper:]' '[:lower:]'`"
+TEST_RAVEN_REPO="`echo "$TEST_RAVEN_REPO" | tr '[:upper:]' '[:lower:]'`"
+TEST_ESGF_COMPUTE_API_REPO="`echo "$TEST_ESGF_COMPUTE_API_REPO" | tr '[:upper:]' '[:lower:]'`"
+
+NOTEBOOKS_TO_TEST="notebooks/*.ipynb"
+if [ x"$TEST_PAVICS_SDI_REPO" = xtrue ]; then
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $PAVICS_SDI_REPO_NAME-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
+fi
+if [ x"$TEST_FINCH_REPO" = xtrue ]; then
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $FINCH_REPO_NAME-$FINCH_BRANCH/docs/source/notebooks/*.ipynb"
+fi
+if [ x"$TEST_RAVEN_REPO" = xtrue ]; then
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $RAVEN_REPO_NAME-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb"
+fi
+if [ x"$TEST_ESGF_COMPUTE_API_REPO" = xtrue ]; then
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
+fi
+
 # last notebooks higher chance for name clash
-./runtest "notebooks/*.ipynb \
-    $FINCH_REPO_NAME-$FINCH_BRANCH/docs/source/notebooks/*.ipynb \
-    $PAVICS_SDI_REPO_NAME-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
-# $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
-# $RAVEN_REPO_NAME-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb
+./runtest "$NOTEBOOKS_TO_TEST"
 EXIT_CODE="$?"
 
 


### PR DESCRIPTION
This is the matching PR for the jenkins-master PR https://github.com/Ouranosinc/jenkins-config/pull/6.

It make use of all the new env var `IS_PROD`, `ENABLE_SCHEDULED_TRIGGER`, and `DEFAULT_PAVICS_HOST`.

I also add the option to feature toogle all the external repos that this repo get all the notebooks to test.

Now we can choose which repo to test its notebooks, instead of having to test all of them.
Advantages:
* More focused/faster test on manual run to only test the repo we are interested in.
* Allow to add new repos that are not ready for nightlies directly to `master` branch (toogle disabled by default) instead of having to have separate branches that require ongoing maintenance to avoid diverging from `master`.  This applies to Raven and ESGF notebooks.

Will delete the 2 branches https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/tree/enable-raven-notebooks-in-jenkins and https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/tree/enable-esgf-notebooks-in-jenkins after this PR is merged.

Nightlies still use default like before (only pavics-sdi and finch notebooks are enabled) so no change.

@huard, @tlogan2000 FYI, no need to approve.

