### PR TITLE
docker: add regionmask and salem for Era5 Raven notebooks, removed jupyter_bokeh

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200120"
+            image "pavics/workflow-tests:200309"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200120
+FROM pavics/workflow-tests:200309
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,8 +35,8 @@ RUN jupyter lab build
 # for ipywidgets to work with jupyter lab (notebooks works out of the box)
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
-    && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
-    && jupyter labextension install @bokeh/jupyter_bokeh
+    && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet
+#    && jupyter labextension install @bokeh/jupyter_bokeh
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -3,7 +3,7 @@ name: birdy
 channels:
   - conda-forge
   - cdat
-  - bokeh
+#  - bokeh
   - defaults
 dependencies:
   - matplotlib
@@ -20,7 +20,7 @@ dependencies:
   - geopandas
   - ipyleaflet
   - threddsclient
-  - bokeh
+#  - bokeh
   - regionmask
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
@@ -37,7 +37,7 @@ dependencies:
   - jupyter
   # to be launched by image jupyterhub/jupyterhub
   - notebook
-  - jupyterlab==1.2.5
+  - jupyterlab
   - jupyterhub
   # to diff .ipynb files
   - nbdime
@@ -54,3 +54,4 @@ dependencies:
     - pixiedust
     - requests-magpie
     - salem
+    - bokeh

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - jupyter
   # to be launched by image jupyterhub/jupyterhub
   - notebook
-  - jupyterlab
+  - jupyterlab==1.2.5
   - jupyterhub
   # to diff .ipynb files
   - nbdime

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - ipyleaflet
   - threddsclient
   - bokeh
+  - regionmask
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
   # - xclim
@@ -52,3 +53,4 @@ dependencies:
     # visual debugger for Jupyter Notebook, not working with JupyterLab at this moment
     - pixiedust
     - requests-magpie
+    - salem

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -54,4 +54,3 @@ dependencies:
     - pixiedust
     - requests-magpie
     - salem
-    - bokeh

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200120"
+    DOCKER_IMAGE="pavics/workflow-tests:200309"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200120"
+    DOCKER_IMAGE="pavics/workflow-tests:200309"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
jupyter_bokeh (the extension, not the package) was removed due to this issue https://github.com/bokeh/jupyter_bokeh/issues/93

Era5 Raven notebook PR: https://github.com/Ouranosinc/raven/pull/200

Noticeable  rather large Jupyter env changes:

```diff
<   - birdy=v0.6.5=py_0
>   - birdy=v0.6.6=py_0

<   - bokeh=1.4.0=py36_0
>     - bokeh==2.0.0  # from pip recursive dependencies (we get newer version by not explicitly get from conda !)


<   - esgf-compute-api=2.2.1=py_2
>   - esgf-compute-api=2.2.3=py_0

<   - jupyterlab=1.2.5=py_0
>   - jupyterlab=2.0.1=py_0

<   - owslib=0.19.0=py_2
>   - owslib=0.19.1=py_0

<   - pandas=0.25.3=py36hb3f55d8_0
>   - pandas=1.0.1=py37hb3f55d8_0

<   - python=3.6.7=h357f687_1006
>   - python=3.7.6=h357f687_4_cpython

>   - regionmask=0.5.0=py_1

<   - xarray=0.14.1=py_1
>   - xarray=0.15.0=py_0

<     - dask==2.9.2
>     - dask==2.12.0

>     - salem==0.2.4

<     - xclim==0.13.0
>     - xclim==0.14.0
```

Full conda env export Diff:
[200120-200309-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4309639/200120-200309-conda-env-export.diff.txt)

Full new conda env export:
[200309-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4309640/200309-conda-env-export.yml.txt)
