### PR TITLE
jupyter docker: upgrade birdy, pin pandas and geopandas for Era5 Raven notebooks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200309"
+            image "pavics/workflow-tests:200310"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200310"
+            image "pavics/workflow-tests:200312"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200309
+FROM pavics/workflow-tests:200310
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200310
+FROM pavics/workflow-tests:200312
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - jupyter
   # to be launched by image jupyterhub/jupyterhub
   - notebook
-  - jupyterlab
+  - jupyterlab==1.2.5
   - jupyterhub
   # to diff .ipynb files
   - nbdime

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - matplotlib
   - xarray
   - numpy
-  - birdy
+#  - birdy
   - owslib>=0.19.0
   - netcdf4
   - pydap
@@ -54,3 +54,4 @@ dependencies:
     - pixiedust
     - requests-magpie
     - salem
+    - -e git+https://github.com/bird-house/birdy@v0.6.8#egg=birdhouse-birdy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -51,9 +51,9 @@ dependencies:
   # for pip packages
   - pip
   - pip:
+    - birdhouse-birdy
     - xclim
     # visual debugger for Jupyter Notebook, not working with JupyterLab at this moment
     - pixiedust
     - requests-magpie
     - salem
-    - -e git+https://github.com/bird-house/birdy@v0.6.8#egg=birdhouse-birdy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -17,7 +17,9 @@ dependencies:
   - descartes
   - rasterio
   - gdal  # for osgeo
-  - geopandas
+  - geopandas==0.6.2
+  - pandas==0.25.3
+  - scikit-image
   - ipyleaflet
   - threddsclient
 #  - bokeh

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -17,6 +17,8 @@ dependencies:
   - descartes
   - rasterio
   - gdal  # for osgeo
+# can unpin geopandas and pandas once there is newer salem release than 0.2.4
+# test using Raven notebook gridded_data_subset.ipynb
   - geopandas==0.6.2
   - pandas==0.25.3
   - scikit-image

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - jupyter
   # to be launched by image jupyterhub/jupyterhub
   - notebook
-  - jupyterlab==1.2.5
+  - jupyterlab
   - jupyterhub
   # to diff .ipynb files
   - nbdime

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200309"
+    DOCKER_IMAGE="pavics/workflow-tests:200310"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200310"
+    DOCKER_IMAGE="pavics/workflow-tests:200312"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200309"
+    DOCKER_IMAGE="pavics/workflow-tests:200310"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200310"
+    DOCKER_IMAGE="pavics/workflow-tests:200312"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
This is to productize all the manual `pip install --user` we had to do to demo Era5 Raven notebook PR: https://github.com/Ouranosinc/raven/pull/200

birdy updated for Raven, then for Finch.

Pinning of pandas and geopandas is due to salem not supporting geopandas >= 0.7 as in this issue https://github.com/fmaussion/salem/issues/152 so can unpin once there are new release of salem.

scikit-image was also need by Raven notebook `gridded_data_subset.ipynb`.

The ipyleaflet marker do not display in Raven `Region_selection.ipynb` but can be moved and its coordinate can be extracted.

Not sure why, maybe relate to https://github.com/jupyter-widgets/ipyleaflet/issues/91.  Possibly also due to the freshly released jupyterlab-2.0 but downgrading jupyterlab means downgrading all the other jupyter extensions we used, too much work to just fix one broken extension so did not follow that road.

The marker was working fine in the previous image `pavics/workflow-tests:200120` which had jupyterlab-1.2.5 which further support the theory that jupyterlab-2.0 broke it.

Noticeable Jupyter env changes:

```diff
<   - birdy=v0.6.6=py_0
>     - birdhouse-birdy==0.6.9  (install from Pypi instead of Conda to fix DockerHub failure !)

<   - geopandas=0.7.0=py_1
>   - geopandas=0.6.2=py_0 

<   - pandas=1.0.1=py37hb3f55d8_0                                                                                                                     
>   - pandas=0.25.3=py37hb3f55d8_0

>   - scikit-image=0.16.2=py37hb3f55d8_0
```

Full conda env export Diff:
[200309-200310-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4315141/200309-200310-conda-env-export.diff.txt)

[200309-200312-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4326058/200309-200312-conda-env-export.diff.txt)

[200310-200312-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4326073/200310-200312-conda-env-export.diff.txt)


Full new conda env export:
[200310-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4315142/200310-conda-env-export.yml.txt)

[200312-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4326061/200312-conda-env-export.yml.txt)


