### PR TITLE
output-sanitize.cfg: try to make notebooks work on both Travis-CI and Jenkins

### DIFF
--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -54,8 +54,15 @@ replace: HYDROGRAPH,/tmp/pywps_process_RANDOM/input.nc,
 regex: 100%\sDone\s|\s+\d.\d\d?s
 replace: 100% Done |  1.0s
 
+## Harmonize both Jenkins (Production) and Travis-CI wps output url to
+#  the same "replace" so both can compare againsts each other.
+
+[travis-ci_wps_output_url]
+# output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
+regex: http://localhost:\d+/outputs/
+replace: https://WPS_HOST/wpsoutputs/
+
 [production_wps_output_url]
-# REFUSE on Jenkins: output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
-# ACCEPT on Travis-CI: output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
+# output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
 regex: https://[a-z0-9_\-\.]+/wpsoutputs/
 replace: https://WPS_HOST/wpsoutputs/

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -53,3 +53,13 @@ replace: HYDROGRAPH,/tmp/pywps_process_RANDOM/input.nc,
 [print_wps_resp_log]
 regex: 100%\sDone\s|\s+\d.\d\d?s
 replace: 100% Done |  1.0s
+
+[travis-ci_wps_output_url]
+# output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
+regex: http://localhost:\d+/outputs/
+replace: http://localhost:port/outputs/
+
+[production_wps_output_url]
+# output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
+regex: https://[a-z0-9_\-\.]+/wpsoutputs/
+replace: https://WPS_HOST/wpsoutputs/

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -54,12 +54,8 @@ replace: HYDROGRAPH,/tmp/pywps_process_RANDOM/input.nc,
 regex: 100%\sDone\s|\s+\d.\d\d?s
 replace: 100% Done |  1.0s
 
-[travis-ci_wps_output_url]
-# output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
-regex: http://localhost:\d+/outputs/
-replace: http://localhost:port/outputs/
-
 [production_wps_output_url]
-# output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
+# REFUSE on Jenkins: output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
+# ACCEPT on Travis-CI: output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
 regex: https://[a-z0-9_\-\.]+/wpsoutputs/
 replace: https://WPS_HOST/wpsoutputs/


### PR DESCRIPTION
Add regex sanitize for WPS output url.

Both production Jenkins (https://pavics.ouranos.ca/wpsoutputs/) and and non-production Travis-CI (http://localhost:5000/outputs/) WPS output url are accepted.  This means non-production url in notebooks won't be caught by Jenkins.  Don't like this, but no easy solution yet.

For Finch PR https://github.com/bird-house/finch/pull/112

Tested on Jenkins but un-tested on Travis-CI.

Passed Jenkins run http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/add-regex-to-output-sanitize-cfg-for-Travis-CI/5/console.

@davidcaron Can you help test this one on Travis-CI?