### PR TITLE
output-sanitize.cfg: add temp folder from Finch notebook

### DIFF
--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -66,3 +66,8 @@ replace: https://WPS_HOST/wpsoutputs/
 # output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
 regex: https://[a-z0-9_\-\.]+/wpsoutputs/
 replace: https://WPS_HOST/wpsoutputs/
+
+[finch-nb-temp-folder]
+# Downloading to /tmp/tmp8fi43lm1/frost-days_SRES-A2-experiment_20460101-20650101.nc
+regex: /tmp/tmp[a-z0-9]+/
+replace: /tmp/tmpRANDOM/


### PR DESCRIPTION
Blind fix for Pr https://github.com/bird-house/finch/pull/114/ since no
updated Finch server for testing.

New regex not adding more errors to Jenkins vs old Finch: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/output-sanitize-for-Finch-nb/2/console