### PR TITLE
Add more sanitize regex for flyingpigeon

### DIFF
--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -62,6 +62,11 @@ replace: 100% Done |  1.0s
 regex: http://localhost:\d+/outputs/
 replace: https://WPS_HOST/wpsoutputs/
 
+[local-run_wps_output_url]
+# <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmpirlo_k7d.png" width="400"/>
+regex: http://127\.0\.0\.1:\d+/outputs/
+replace: https://WPS_HOST/wpsoutputs/
+
 [production_wps_output_url]
 # output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
 regex: https://[a-z0-9_\-\.]+/wpsoutputs/

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -71,3 +71,8 @@ replace: https://WPS_HOST/wpsoutputs/
 # Downloading to /tmp/tmp8fi43lm1/frost-days_SRES-A2-experiment_20460101-20650101.nc
 regex: /tmp/tmp[a-z0-9]+/
 replace: /tmp/tmpRANDOM/
+
+[flyingpigeon-nb-temp-output-png-image]
+# <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmpirlo_k7d.png" width="400"/>
+regex: /tmp[a-zA-Z0-9_]{8}\.png
+replace: /tmpRANDOM.png


### PR DESCRIPTION
@nilshempelmann here are the additional regexes for your FlyingPigeon PR https://github.com/bird-house/flyingpigeon/pull/321

Should handle
```
    assert reference_output == test_output failed:

      '<img src="ht...width="400"/>' == '<img src="ht...width="400"/>'
      - <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmpirlo_k7d.png" width="400"/>
      ?                                                        ^^  ----
      + <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmplwz7aplo.png" width="400"/>
      ?                                                        ^^^^^^
```