### PR TITLE
release: update to use image pavics/workflow-tests:200427

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200312"
+            image "pavics/workflow-tests:200427"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200312
+FROM pavics/workflow-tests:200427
 
 USER root
 

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200312"
+    DOCKER_IMAGE="pavics/workflow-tests:200427"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200312"
+    DOCKER_IMAGE="pavics/workflow-tests:200427"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
New build of our Jupyter env.

Required update to the notebooks for owslib and xarray breaking changes, see commit https://github.com/Ouranosinc/pavics-sdi/commit/08325cb64ff9b41ec578e2bc1855deb1debdbfc8 or PR https://github.com/Ouranosinc/pavics-sdi/pull/170.

Noticeable changes:
```diff
# geopandas switched from conda to pip package
# this is a little bit odd since we pinned the conda version to 0.6.2
# should not be the cause of Jenkins failure since Raven tests are not enabled yet
<   - geopandas=0.6.2=py_0
>     - geopandas==0.7.0

<   - xarray=0.15.0=py_0
>   - xarray=0.15.1=py_0

<   - owslib=0.19.1=py_0
>   - owslib=0.19.2=py_1

<   - dask-core=2.12.0=py_0
>   - dask-core=2.15.0=py_0

<     - distributed==2.12.0
>     - distributed==2.15.0   

<     - xclim==0.14.0
>     - xclim==0.16.0
```

Full conda env export diff:
[200312-200427-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4547396/200312-200427-conda-env-export.diff.txt)

Full new conda env content:
[200427-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4547399/200427-conda-env-export.yml.txt)

