### PR TITLE
docker: new build to remove salem, replaced by rioxarray and add packages for the custom_climate_portraits branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200506"
+            image "pavics/workflow-tests:200507"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200427"
+            image "pavics/workflow-tests:200506"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200427
+FROM pavics/workflow-tests:200506
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200506
+FROM pavics/workflow-tests:200507
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,8 +36,7 @@ RUN jupyter lab build
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
-    && jupyter labextension install @bokeh/jupyter_bokeh \
-    && jupyter labextension install @pyviz/jupyterlab_pyviz
+    && jupyter labextension install @bokeh/jupyter_bokeh
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM conda/miniconda3
+FROM continuumio/miniconda3
 
 RUN conda update conda
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN groupadd --gid 1000 jenkins \
     && useradd --uid 1000 --gid jenkins --create-home jenkins
 
 # alternate way to 'source activate birdy'
-ENV PATH="/usr/local/envs/birdy/bin:$PATH"
+ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 
 # our notebooks are hardcoded to lookup for kernel named 'birdy'
 # this python is from the birdy env above

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN python -m ipykernel install --name birdy
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
 # environment.yml above
-# RUN conda install -n birdy -c conda-forge -c cdat -c bokeh -c defaults nbdime
+# RUN conda install -c conda-forge -c cdat -c bokeh -c defaults nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 RUN jupyter lab build
@@ -35,8 +35,8 @@ RUN jupyter lab build
 # for ipywidgets to work with jupyter lab (notebooks works out of the box)
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
-    && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet
-#    && jupyter labextension install @bokeh/jupyter_bokeh
+    && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
+    && jupyter labextension install @bokeh/jupyter_bokeh
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,8 @@ RUN jupyter lab build
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
-    && jupyter labextension install @bokeh/jupyter_bokeh
+    && jupyter labextension install @bokeh/jupyter_bokeh \
+    && jupyter labextension install @pyviz/jupyterlab_pyviz
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -17,10 +17,9 @@ dependencies:
   - descartes
   - rasterio
   - gdal  # for osgeo
-# can unpin geopandas and pandas once there is newer salem release than 0.2.4
-# test using Raven notebook gridded_data_subset.ipynb
-  - geopandas==0.6.2
-  - pandas==0.25.3
+  - geopandas
+  - pandas
+  - rioxarray
   - scikit-image
   - ipyleaflet
   - threddsclient
@@ -58,4 +57,3 @@ dependencies:
     # visual debugger for Jupyter Notebook, not working with JupyterLab at this moment
     - pixiedust
     - requests-magpie
-    - salem

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - panel
   - holoviews
   - geoviews
+  - hvplot
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
   # - xclim

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -3,7 +3,7 @@ name: birdy
 channels:
   - conda-forge
   - cdat
-#  - bokeh
+  - bokeh
   - defaults
 dependencies:
   - matplotlib
@@ -23,8 +23,15 @@ dependencies:
   - scikit-image
   - ipyleaflet
   - threddsclient
-#  - bokeh
+  - bokeh
   - regionmask
+  - siphon
+  - jupyter_bokeh
+  - pscript
+  - h5netcdf
+  - panel
+  - holoviews
+  - geoviews
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock
   # - xclim
@@ -57,3 +64,5 @@ dependencies:
     # visual debugger for Jupyter Notebook, not working with JupyterLab at this moment
     - pixiedust
     - requests-magpie
+    # block execution of 'run_all_cells' until user input finished
+    - ipython_blocking

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200506"
+    DOCKER_IMAGE="pavics/workflow-tests:200507"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200427"
+    DOCKER_IMAGE="pavics/workflow-tests:200506"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200427"
+    DOCKER_IMAGE="pavics/workflow-tests:200506"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200506"
+    DOCKER_IMAGE="pavics/workflow-tests:200507"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
Now we do not need a separate docker build for the [`custom_climate_portraits`](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/tree/custom_climate_portraits) branch (PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/35).  That branch should only be used for notebook changes.  Jupyter env change should directly PR to `master`.

Did not add the full `holoviz` package since it seems to freeze the build (stuck in Solving Environment for more than 25 mins).

Also changed the base image to continuumio/miniconda3 since the previous one was deprecated.

Raven PR https://github.com/Ouranosinc/raven/pull/266 (commit https://github.com/Ouranosinc/raven/commit/0763bf52abec1bc0a70927de3a2dc2cc1cf77ec3) removed salem dependency and replaced with rioxarray.

salem was previously introduced in PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/36 (commit https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/f916beadf8f9056e76ed88a52bdfb221c3ee7fb8).

Passing Jenkins build: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-image-to-remove-salem-replaced-by-rioxarray/lastSuccessfulBuild/console, new docker build: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-image-to-remove-salem-replaced-by-rioxarray/4/console

Jenkins build against Raven notebooks no import error http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-image-to-remove-salem-replaced-by-rioxarray/3/consoleFull

Noticeable changes:
```diff
# conda release of bokeh seems to trail behind pypi 
>   - bokeh=2.0.1=py37hc8dfbb8_0
<     - bokeh==2.0.2 
>   - jupyter_bokeh=2.0.1=py_0

# should already exist, not sure why conda env export report this as new
>   - dask=2.15.0=py_0

# unpinned since salem is removed
<   - pandas=0.25.3=py37hb3f55d8_0
>   - pandas=1.0.3=py37h0da4684_1

<     - salem==0.2.4
>   - rioxarray=0.0.26=py_0

# packages for custom_climate_portraits branch
>   - geoviews=1.8.1=py_0
>   - h5netcdf=0.8.0=py_0
>   - holoviews=1.13.2=pyh9f0ad1d_0
>   - panel=0.9.5=py_1
>   - hvplot=0.5.2=py_0
>   - pscript=0.7.3=py_0
>   - siphon=0.8.0=py37_1002
>     - ipython-blocking==0.2.1
```

Full conda env export Diff:
[200427-200506-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4590227/200427-200506-conda-env-export.diff.txt)

[200506-200507-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4594860/200506-200507-conda-env-export.diff.txt)


Full new conda env export:
[200506-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4590228/200506-conda-env-export.yml.txt)

[200507-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4594861/200507-conda-env-export.yml.txt)

