### PR TITLE
docker: new jupyter extensions: jupyter-archive, visual debugger, jupyter-dash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200603"
+            image "pavics/workflow-tests:200605"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200603
+FROM pavics/workflow-tests:200605
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,8 +38,8 @@ RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
     && jupyter labextension install @bokeh/jupyter_bokeh \
     && jupyter labextension install @pyviz/jupyterlab_pyviz \
-    && jupyter labextension install @jupyterlab/debugger \
-    && jupyter labextension install jupyterlab-clipboard
+    && jupyter labextension install @jupyterlab/debugger
+#    && jupyter labextension install jupyterlab-clipboard
 
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN python -m ipykernel install --name birdy
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
 # environment.yml above
-# RUN conda install -c conda-forge -c cdat -c bokeh -c defaults nbdime
+# RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 RUN jupyter lab build
@@ -37,7 +37,10 @@ RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
     && jupyter labextension install @bokeh/jupyter_bokeh \
-    && jupyter labextension install @pyviz/jupyterlab_pyviz
+    && jupyter labextension install @pyviz/jupyterlab_pyviz \
+    && jupyter labextension install @jupyterlab/debugger \
+    && jupyter labextension install jupyterlab-clipboard
+
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - cdat
   - bokeh
+  - plotly  # for jupyter-dash
   - defaults
 dependencies:
   - matplotlib
@@ -54,6 +55,10 @@ dependencies:
   - nbdime
   # Voila turns Jupyter notebooks into standalone web applications
   - voila
+  - jupyter-archive
+  # xeus-python: back-end kernel implementing the Jupyter Debug Protocol
+  - xeus-python
+  - jupyter-dash
   # utilities
   - curl
   - wget

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200603"
+    DOCKER_IMAGE="pavics/workflow-tests:200605"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200603"
+    DOCKER_IMAGE="pavics/workflow-tests:200605"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
Deployed to https://medus.ouranos.ca/jupyter for testing.

Jenkins build passed http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-jupyter-extensions/2/console

Part of issue https://github.com/Ouranosinc/pavics-sdi/issues/141.

Added:

* https://github.com/hadim/jupyter-archive
  Download entire folder as archive.

* https://blog.jupyter.org/a-visual-debugger-for-jupyter-914e61716559

* https://github.com/plotly/jupyter-dash
  Develop Plotly Dash apps interactively from within Jupyter environments.

Noticeable changes:
```diff
>   - jupyter-archive=0.6.2=py_0                                                                                                                      
>   - jupyter-dash=0.2.1.post1=py_0

<   - owslib=0.19.2=py_1
>   - owslib=0.20.0=py_0

>   - xeus-python=0.7.1=py37h99015e2_1
```

Could not enable jupyter-clipboard, see error in commit d52ede56c553405892b482204b1fc85d3b894f85

Conda env export diff:
[200603-200605-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4748928/200603-200605-conda-env-export.diff.txt)

Full conda env export:
[200605-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/4748931/200605-conda-env-export.yml.txt)


