### PR TITLE
New docker build and pin old hvplot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200716"
+            image "pavics/workflow-tests:200730"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200730"
+            image "pavics/workflow-tests:200803"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200730
+FROM pavics/workflow-tests:200803
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200716
+FROM pavics/workflow-tests:200730
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -33,7 +33,9 @@ dependencies:
   - panel
   - holoviews
   - geoviews
-  - hvplot
+  # unpin hvplot when https://github.com/holoviz/hvplot/issues/498 (violin plot
+  # not working with hvplot 0.6.0) is fixed
+  - hvplot==0.5.2
   - nc-time-axis
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -44,7 +44,8 @@ dependencies:
   - vcs
   - mesalib
   # tests
-  - pytest
+  # pin pytest, see https://github.com/bird-house/cookiecutter-birdhouse/commit/b6969697401008114c8e25846ae5801e7e65224d
+  - pytest==5.4.3
   - nbval
   # to edit .ipynb
   - jupyter

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -44,8 +44,7 @@ dependencies:
   - vcs
   - mesalib
   # tests
-  # pin pytest, see https://github.com/bird-house/cookiecutter-birdhouse/commit/b6969697401008114c8e25846ae5801e7e65224d
-  - pytest==5.4.3
+  - pytest
   - nbval
   # to edit .ipynb
   - jupyter

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200716"
+    DOCKER_IMAGE="pavics/workflow-tests:200730"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200730"
+    DOCKER_IMAGE="pavics/workflow-tests:200803"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200716"
+    DOCKER_IMAGE="pavics/workflow-tests:200730"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200730"
+    DOCKER_IMAGE="pavics/workflow-tests:200803"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
Pin hvplot for https://github.com/holoviz/hvplot/issues/498 (violin plot not working in latest hvplot 0.6.0).

Jenkins successful build: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-and-pin-pytest/4/console (with pavics-sdi PR https://github.com/Ouranosinc/pavics-sdi/pull/173).

Noticeable changes:
```diff
<   - hvplot=0.6.0=pyh9f0ad1d_0
>   - hvplot=0.5.2=py_0

<   - dask=2.20.0=py_0
>   - dask=2.22.0=py_0

<   - geopandas=0.8.0=py_1
>   - geopandas=0.8.1=py_0

<   - pandas=1.0.5=py37h0da4684_0
>   - pandas=1.1.0=py37h3340039_0

<   - matplotlib=3.2.2=1
>   - matplotlib=3.3.0=1

<   - numpy=1.18.5=py37h8960a57_0
>   - numpy=1.19.1=py37h8960a57_0

<   - cryptography=2.9.2=py37hb09aad4_0
>   - cryptography=3.0=py37hb09aad4_0

<   - python=3.7.6=h8356626_5_cpython
>   - python=3.7.8=h6f2ec95_1_cpython 

<   - nbval=0.9.5=py_0
>   - nbval=0.9.6=pyh9f0ad1d_0

<   - pytest=5.4.3=py37hc8dfbb8_0
>   - pytest=6.0.1=py37hc8dfbb8_0
```

Full conda env export diff:
[200716-200803-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5018751/200716-200803-conda-env-export.diff.txt)

Full new conda env export (200803):
[200803-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5018753/200803-conda-env-export.yml.txt)

Full new conda env export (200730 not final new image of this PR):
[200730-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5018755/200730-conda-env-export.yml.txt)



