### PR TITLE
docker: periodic rebuild and add handcalcs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200914"
+            image "pavics/workflow-tests:200914.1"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200803"
+            image "pavics/workflow-tests:200914"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200914
+FROM pavics/workflow-tests:200914.1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200803
+FROM pavics/workflow-tests:200914
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -75,3 +75,7 @@ dependencies:
     - requests-magpie
     # block execution of 'run_all_cells' until user input finished
     - ipython_blocking
+    # Mimics how one might format their calculation if it were written with a
+    # pencil: write the symbolic formula, followed by numeric substitutions,
+    # and then the result.
+    - handcalcs

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -33,9 +33,12 @@ dependencies:
   - panel
   - holoviews
   - geoviews
-  # unpin hvplot when https://github.com/holoviz/hvplot/issues/498 (violin plot
-  # not working with hvplot 0.6.0) is fixed
-  - hvplot==0.5.2
+  # this might still be relevant https://github.com/holoviz/hvplot/issues/498
+  # (violin plot not working with hvplot 0.6.0).
+  # Per this comment
+  # https://github.com/bird-house/birdhouse-deploy/pull/63#issuecomment-668270608
+  # pinning hvplot did not solve the problem with violin plot.
+  - hvplot
   - nc-time-axis
   # can re-enable xclim from conda once we have write access to
   # https://github.com/conda-forge/xclim-feedstock

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200803"
+    DOCKER_IMAGE="pavics/workflow-tests:200914"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200914"
+    DOCKER_IMAGE="pavics/workflow-tests:200914.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200803"
+    DOCKER_IMAGE="pavics/workflow-tests:200914"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200914"
+    DOCKER_IMAGE="pavics/workflow-tests:200914.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
Add handcalcs https://github.com/connorferster/handcalcs/ and unpin hvplot since pinning did not solve violin plot issue, see this comment https://github.com/bird-house/birdhouse-deploy/pull/63#issuecomment-668270608

Successful Jenkins build http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/periodic-rebuild-and-add-handcalcs/1/console

Noticeable changes:
```diff
>     - handcalcs==0.8.1

<     - xclim==0.18.0
>     - xclim==0.19.0

<   - hvplot=0.5.2=py_0
>   - hvplot=0.6.0=pyh9f0ad1d_0

<   - dask=2.22.0=py_0
>   - dask=2.26.0=py_0

<   - bokeh=2.1.1=py37hc8dfbb8_0
>   - bokeh=2.2.1=py37hc8dfbb8_0

<   - numba=0.50.1=py37h0da4684_1
>   - numba=0.51.2=py37h9fdb41a_0
```

Full `conda env export` diff:
[200803-200914.1-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5225141/200803-200914.1-conda-env-export.diff.txt)

Full new `conda env export`:
[200914.1-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5225142/200914.1-conda-env-export.yml.txt)

