### PR TITLE
docker: new build for python 3.8, new xclim and memory_profiler

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:200925.1"
+            image "pavics/workflow-tests:201026"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:200925.1
+FROM pavics/workflow-tests:201026
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -41,6 +41,10 @@ dependencies:
   - hvplot
   - nc-time-axis
   - xclim
+  # https://anaconda.org/anaconda/memory_profiler
+  # Monitor memory consumption of a process as well as line-by-line analysis
+  # of memory consumption for Python programs.
+  - memory_profiler
   # for esgf notebooks
   - esgf-compute-api
   - cdms2

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200925.1"
+    DOCKER_IMAGE="pavics/workflow-tests:201026"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:200925.1"
+    DOCKER_IMAGE="pavics/workflow-tests:201026"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
Python upgraded from 3.7 to 3.8.  Any possible potential problem? @huard @tlogan2000 

Jenkins build no new error except the known "WMS_example.ipynb: ​​neowms.sci.gsfc.nasa.gov ​​timed ​​out " http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-build-for-new-xclim/2/console

`memory_profiler` was for Pascal.

Relevant changes:
```diff
# Python 3.8 !
<   - python=3.7.8=h6f2ec95_1_cpython
>   - python=3.8.6=h852b56e_0_cpython

<   - xclim=0.20.0=py_0
>   - xclim=0.21.0=py_0

<   - dask=2.27.0=py_0
>   - dask=2.30.0=py_0

<   - rioxarray=0.0.31=py_0
>   - rioxarray=0.1.0=py_0

>   - memory_profiler=0.58.0=py_0
```

Full `conda env export` diff:
[200925.1-201026-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5440884/200925.1-201026-conda-env-export.diff.txt)

Full new `conda env export`:
[201026-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5440885/201026-conda-env-export.yml.txt)
