### PR TITLE
docker: adds 4 jupyterlab extensions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:201026"
+            image "pavics/workflow-tests:201111"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:201026
+FROM pavics/workflow-tests:201111
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,10 +60,6 @@ ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook
 RUN chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions; \
     chmod a+r /etc/jupyter/jupyter_notebook_config.py
 
-
-COPY drive.jupyterlab-settings "/home/jenkins/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings"
-RUN chown -R jenkins /home/jenkins/.jupyter
-
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here
 USER jenkins

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,13 +39,18 @@ RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter labextension install @bokeh/jupyter_bokeh \
     && jupyter labextension install @pyviz/jupyterlab_pyviz \
     && jupyter labextension install @jupyterlab/debugger \
+    && jupyter labextension install @jupyterlab/google-drive \
     && jupyter labextension install jupyterlab-topbar-extension \
                                     jupyterlab-system-monitor \
                                     jupyterlab-topbar-text \
                                     jupyterlab-logout \
-                                    jupyterlab-theme-toggle
+                                    jupyterlab-theme-toggle \
+                                    jupyterlab_conda
 #    && jupyter labextension install jupyterlab-clipboard
 
+ENV USER jenkins
+
+COPY drive.jupyterlab-settings "/home/$USER/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings"
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/
@@ -55,9 +60,17 @@ ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook
 RUN chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions; \
     chmod a+r /etc/jupyter/jupyter_notebook_config.py
 
+# Change these folders' permissions for jupyter extensions
+RUN chmod -R 777 /home/jenkins/.jupyter
+RUN chmod -R 777 /opt/conda
+
+RUN python -m ipykernel install
+
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here
-USER jenkins
+USER $USER
+
+RUN conda init bash
 
 # follow jupyter/base-notebook image so config in jupyterhub is simpler
-CMD ["/usr/local/bin/start-notebook.sh"]
+CMD ["conda", "run", "-n", "birdy", "/usr/local/bin/start-notebook.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,12 +9,16 @@ RUN apt-get update && \
 
 COPY environment.yml /environment.yml
 
-# create env "birdy"
-RUN conda env create -f /environment.yml
-
 # needed for our specific jenkins
 RUN groupadd --gid 1000 jenkins \
     && useradd --uid 1000 --gid jenkins --create-home jenkins
+
+# Change these folders' permissions for jupyter-conda extension
+RUN chmod -R a+rwx /opt/conda
+
+# create env "birdy"
+# use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
+RUN umask 0000 && conda env create -f /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
@@ -48,10 +52,6 @@ RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
                                     jupyterlab_conda
 #    && jupyter labextension install jupyterlab-clipboard
 
-ENV USER jenkins
-
-COPY drive.jupyterlab-settings "/home/$USER/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings"
-
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh /usr/local/bin/
@@ -60,17 +60,14 @@ ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook
 RUN chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions; \
     chmod a+r /etc/jupyter/jupyter_notebook_config.py
 
-# Change these folders' permissions for jupyter extensions
-RUN chmod -R 777 /home/jenkins/.jupyter
-RUN chmod -R 777 /opt/conda
 
-RUN python -m ipykernel install
+COPY drive.jupyterlab-settings "/home/jenkins/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings"
+RUN chown -R jenkins /home/jenkins/.jupyter
 
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here
-USER $USER
-
-RUN conda init bash
+USER jenkins
 
 # follow jupyter/base-notebook image so config in jupyterhub is simpler
+# start notebook in conda environment to have working jupyter extensions
 CMD ["conda", "run", "-n", "birdy", "/usr/local/bin/start-notebook.sh"]

--- a/docker/drive.jupyterlab-settings
+++ b/docker/drive.jupyterlab-settings
@@ -1,0 +1,1 @@
+{"clientId":"922922467672-anhofi89or5uuc4ggu1s2p4dpi76c33r.apps.googleusercontent.com"}

--- a/docker/drive.jupyterlab-settings
+++ b/docker/drive.jupyterlab-settings
@@ -1,1 +1,0 @@
-{"clientId":"922922467672-anhofi89or5uuc4ggu1s2p4dpi76c33r.apps.googleusercontent.com"}

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -57,6 +57,12 @@ dependencies:
   - jupyterhub
   # to diff .ipynb files
   - nbdime
+  # extension to produce .py files from notebook .ipynb files
+  - jupytext
+  # jupyterlab extension for git
+  - jupyterlab-git
+  # jupyterlab extension for conda
+  - jupyter_conda
   # Voila turns Jupyter notebooks into standalone web applications
   - voila
   - jupyter-archive

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:201026"
+    DOCKER_IMAGE="pavics/workflow-tests:201111"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:201026"
+    DOCKER_IMAGE="pavics/workflow-tests:201111"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
Adds 4 jupyterlab extensions to the docker image : jupytext, jupyterlab-google-drive, jupyter_conda and jupyterlab-git

Relevant changes:
```diff
>   - jupyter_conda=3.4.1=pyh9f0ad1d_0
>   - jupyterlab-git=0.22.3=pyhd8ed1ab_0
>   - jupytext=1.6.0=pyh9f0ad1d_0

<   - jupyterhub=1.1.0=py38h32f6830_5
>   - jupyterhub=1.2.1=py38h578d9bd_0
```

Passing Jenkins build: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/add-notebook-tools/9/console

Full `conda env export` diff:
[201026-201111-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5527818/201026-201111-conda-env-export.diff.txt)

Full new `conda env export`:
[201111-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5527819/201111-conda-env-export.yml.txt)

Matching PR https://github.com/bird-house/birdhouse-deploy/pull/97 for jupyterlab-google-drive config.

Matching PR https://github.com/Ouranosinc/pavics-sdi/pull/185 for documentation about the new extensions.