### PR TITLE
docker: new build to get updates and add cfgrib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:201111"
+            image "pavics/workflow-tests:201214"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:201111
+FROM pavics/workflow-tests:201214
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -13,6 +13,10 @@ dependencies:
 #  - birdy
   - owslib>=0.19.0
   - netcdf4
+  # https://github.com/ecmwf/cfgrib
+  # Python interface to map GRIB files to the Unidata's Common Data Model v4
+  # following the CF Conventions.
+  - cfgrib
   - pydap
   - cartopy
   - descartes

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:201111"
+    DOCKER_IMAGE="pavics/workflow-tests:201214"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:201111"
+    DOCKER_IMAGE="pavics/workflow-tests:201214"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
`cfgrib` added for PR https://github.com/Ouranosinc/pavics-vdb/pull/21.

Jenkins build with known error only: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-with-cfgrib/2/console

Corresponding test fix https://github.com/Ouranosinc/pavics-sdi/pull/195.

Corresponding PR to deploy to PAVICS https://github.com/bird-house/birdhouse-deploy/pull/112.

Relevant changes:

```diff

>   - cfgrib=0.9.8.5=pyhd8ed1ab_0

<   - clisops=0.3.1=pyh32f6830_1
>   - clisops=0.4.0=pyhd3deb0d_0

<   - dask=2.30.0=py_0
>   - dask=2020.12.0=pyhd8ed1ab_0

<   - owslib=0.20.0=py_0
>   - owslib=0.21.0=pyhd8ed1ab_0

<   - xarray=0.16.1=py_0
>   - xarray=0.16.2=pyhd8ed1ab_0

<   - xclim=0.21.0=py_0
>   - xclim=0.22.0=pyhd8ed1ab_0

<   - jupyter_conda=3.4.1=pyh9f0ad1d_0
>   - jupyter_conda=4.1.0=hd8ed1ab_1
```

Full `conda env export` diff:
[201111-201214-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5706860/201111-201214-conda-env-export.diff.txt)

Full new `conda env export`:
[201214-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5706861/201214-conda-env-export.yml.txt)
