### PR TITLE
Avoid burden to copy .ncml files to server under test

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ xarray html dataset output which is more rich for the end-users but it breaks
 the checks.  In the case where the cell output is important to assert the
 correctness of the notebook, we can add `# NBVAL_CHECK_OUTPUT` to the cell.
 
+By default we regex replace `pavics.ouranos.ca` to the hostname of the server
+under test to test all components of the server under test.  However, we do not
+perform this regex replace for `.ncml` links so `.ncml` links will come from
+our production server `pavics.ouranos.ca`.  The reason is that `.ncml` files
+require a large amount of `.nc` matching files to be copied to the server under
+test so we want to avoid this setup burden for the server under test.  Regular
+`.nc` files will still have to be copied over so the Thredds component is
+tested.
+
 
 ## Adding more notebooks to tests
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Test user-level end-to-end workflow.
 
 ## Description
 This repo ensure the various Jupyter notebooks run without errors against the
-chosen PAVICS server and still produce approximatively the same output.
+chosen PAVICS server and still produce the same output.
 
 Resulting benefits:
 
@@ -94,12 +94,6 @@ runner can even run notebooks from several external repos (current also
 running the notebooks from the
 [pavics-sdi](https://github.com/Ouranosinc/pavics-sdi/tree/master/docs/source/notebooks)
 repo, more can be added easily).
-
-By default, we do not check notebooks cell output to avoid compromising the
-documentation role of the notebooks.  If we did, we would not be able to use
-xarray html dataset output which is more rich for the end-users but it breaks
-the checks.  In the case where the cell output is important to assert the
-correctness of the notebook, we can add `# NBVAL_CHECK_OUTPUT` to the cell.
 
 By default we regex replace `pavics.ouranos.ca` to the hostname of the server
 under test to test all components of the server under test.  However, we do not

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Test user-level end-to-end workflow.
 
 ## Description
 This repo ensure the various Jupyter notebooks run without errors against the
-chosen PAVICS server and still produce the same output.
+chosen PAVICS server and still produce approximatively the same output.
 
 Resulting benefits:
 
@@ -94,6 +94,12 @@ runner can even run notebooks from several external repos (current also
 running the notebooks from the
 [pavics-sdi](https://github.com/Ouranosinc/pavics-sdi/tree/master/docs/source/notebooks)
 repo, more can be added easily).
+
+By default, we do not check notebooks cell output to avoid compromising the
+documentation role of the notebooks.  If we did, we would not be able to use
+xarray html dataset output which is more rich for the end-users but it breaks
+the checks.  In the case where the cell output is important to assert the
+correctness of the notebook, we can add `# NBVAL_CHECK_OUTPUT` to the cell.
 
 
 ## Adding more notebooks to tests

--- a/runtest
+++ b/runtest
@@ -24,7 +24,16 @@ fi
 # so tests still pass when user want to disable ssl cert verification
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
-py.test --nbval $NOTEBOOKS --sanitize-with notebooks/output-sanitize.cfg
+# --nbval-lax do not check notebook cell output.  Add '# NBVAL_CHECK_OUTPUT' to
+# cells that require output check.
+#
+# xarray html dataset output breaks cell output check.  Also prevent harmless
+# changes like field ordering in output, external service version change,
+# timestamp/uuid change to break the run.
+#
+# So for some very important notebook cells, have to remember to activate
+# '# NBVAL_CHECK_OUTPUT' to properly ensure the notebooks are working correctly.
+py.test --nbval-lax $NOTEBOOKS --sanitize-with notebooks/output-sanitize.cfg
 EXIT_CODE="$?"
 
 # lowercase SAVE_RESULTING_NOTEBOOK string

--- a/runtest
+++ b/runtest
@@ -26,16 +26,7 @@ fi
 # so tests still pass when user want to disable ssl cert verification
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
-# --nbval-lax do not check notebook cell output.  Add '# NBVAL_CHECK_OUTPUT' to
-# cells that require output check.
-#
-# xarray html dataset output breaks cell output check.  Also prevent harmless
-# changes like field ordering in output, external service version change,
-# timestamp/uuid change to break the run.
-#
-# So for some very important notebook cells, have to remember to activate
-# '# NBVAL_CHECK_OUTPUT' to properly ensure the notebooks are working correctly.
-py.test --nbval-lax $NOTEBOOKS --sanitize-with notebooks/output-sanitize.cfg
+py.test --nbval $NOTEBOOKS --sanitize-with notebooks/output-sanitize.cfg
 EXIT_CODE="$?"
 
 # lowercase SAVE_RESULTING_NOTEBOOK string

--- a/runtest
+++ b/runtest
@@ -16,7 +16,9 @@ fi
 
 if [ ! -z "$PAVICS_HOST" ]; then
     echo "Will run notebooks against $PAVICS_HOST"
-    sed -i "s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS
+    # .ncml links will always comes from the production server, not the server
+    # under test since we do not perform regex replace for .ncml links.
+    sed -i "/\.ncml/!s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS
     git diff  # not working for notebooks from other repos
 fi
 


### PR DESCRIPTION
Small code change, fairly big impact here.  The README has the background.

Impact:

* (removed, will re-evaluate this next time) With the switch to `--nbval-lax` that disable output checking, some notebook failures might fly under the radar.  We have to audit all notebooks and add the `# NBVAL_CHECK_OUTPUT` to any cells that is critical to the correctness of the notebooks.

* With `.ncml` links always coming from our production `pavics.ouranos.ca` server, this means if the production server is down, tests will fail as well.  This means the tests are less "independent".


