### PR TITLE
docker: new build with ravenpy for raven notebooks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210126"
+            image "pavics/workflow-tests:210201"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:201214"
+            image "pavics/workflow-tests:210126"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210201.1"
+            image "pavics/workflow-tests:210201.2"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210201"
+            image "pavics/workflow-tests:210201.1"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210201
+FROM pavics/workflow-tests:210201.1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210126
+FROM pavics/workflow-tests:210201
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:201214
+FROM pavics/workflow-tests:210126
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210201.1
+FROM pavics/workflow-tests:210201.2
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 # Can move ravenpy install into environment.yml if this issue is resolved
 # https://github.com/conda/conda/issues/10119#issuecomment-767697552.
 RUN python -m ipykernel install --name birdy \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y make && apt-get clean \
     && pip install ravenpy --install-option="--with-binaries"
 
 # install using same channel preferences as birdy original env to not downgrade

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,13 @@ RUN umask 0000 && conda env create -f /environment.yml
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 
+# TODO: remove this hacked pin.  Should pin in environment.yml instead.
+# Added this pin here to not have to rebuild the gigantic `conda env create`
+# layer and also invalidate the layer below to force get latest ravenpy 0.2.3.
+# Pins cftime >= 1.2 < 1.4. Because 1.4 breaks xarray (pydata/xarray#4853).
+# https://github.com/Ouranosinc/xclim/pull/641
+RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults cftime~=1.3
+
 # our notebooks are hardcoded to lookup for kernel named 'birdy'
 # this python is from the birdy env above
 # Make, g++ and libnetcdf-dev needed for ravenpy install using --install-option.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 # layer and also invalidate the layer below to force get latest ravenpy 0.2.3.
 # Pins cftime >= 1.2 < 1.4. Because 1.4 breaks xarray (pydata/xarray#4853).
 # https://github.com/Ouranosinc/xclim/pull/641
-RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults cftime~=1.3
+RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy cftime==1.3.1
 
 # our notebooks are hardcoded to lookup for kernel named 'birdy'
 # this python is from the birdy env above
@@ -43,7 +43,7 @@ RUN python -m ipykernel install --name birdy \
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
 # environment.yml above
-# RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults nbdime
+# RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 RUN jupyter lab build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,10 +25,11 @@ ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 
 # our notebooks are hardcoded to lookup for kernel named 'birdy'
 # this python is from the birdy env above
+# Make and g++ needed for ravenpy install using --install-option.
 # Can move ravenpy install into environment.yml if this issue is resolved
 # https://github.com/conda/conda/issues/10119#issuecomment-767697552.
 RUN python -m ipykernel install --name birdy \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y make && apt-get clean \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y make g++ && apt-get clean \
     && pip install ravenpy --install-option="--with-binaries"
 
 # install using same channel preferences as birdy original env to not downgrade

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,10 @@ ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 
 # our notebooks are hardcoded to lookup for kernel named 'birdy'
 # this python is from the birdy env above
-RUN python -m ipykernel install --name birdy
+# Can move ravenpy install into environment.yml if this issue is resolved
+# https://github.com/conda/conda/issues/10119#issuecomment-767697552.
+RUN python -m ipykernel install --name birdy \
+    && pip install ravenpy --install-option="--with-binaries"
 
 # install using same channel preferences as birdy original env to not downgrade
 # anything accidentally

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,11 +25,11 @@ ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 
 # our notebooks are hardcoded to lookup for kernel named 'birdy'
 # this python is from the birdy env above
-# Make and g++ needed for ravenpy install using --install-option.
+# Make, g++ and libnetcdf-dev needed for ravenpy install using --install-option.
 # Can move ravenpy install into environment.yml if this issue is resolved
 # https://github.com/conda/conda/issues/10119#issuecomment-767697552.
 RUN python -m ipykernel install --name birdy \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y make g++ && apt-get clean \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y make g++ libnetcdf-dev && apt-get clean \
     && pip install ravenpy --install-option="--with-binaries"
 
 # install using same channel preferences as birdy original env to not downgrade

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -44,6 +44,7 @@ dependencies:
   # pinning hvplot did not solve the problem with violin plot.
   - hvplot
   - nc-time-axis
+  - statsmodels  # for ravenpy
   - xclim
   # https://anaconda.org/anaconda/memory_profiler
   # Monitor memory consumption of a process as well as line-by-line analysis

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -11,7 +11,9 @@ dependencies:
   - xarray
   - numpy
 #  - birdy
-  - owslib>=0.19.0
+  # avoid owslib 0.22 with timeout bug
+  # https://github.com/geopython/OWSLib/issues/737
+  - owslib==0.21.0
   - netcdf4
   # https://github.com/ecmwf/cfgrib
   # Python interface to map GRIB files to the Unidata's Common Data Model v4

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -64,7 +64,7 @@ dependencies:
   - jupyter
   # to be launched by image jupyterhub/jupyterhub
   - notebook
-  - jupyterlab
+  - jupyterlab==2.2.9
   - jupyterhub
   # to diff .ipynb files
   - nbdime

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:201214"
+    DOCKER_IMAGE="pavics/workflow-tests:210126"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210201"
+    DOCKER_IMAGE="pavics/workflow-tests:210201.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210201.1"
+    DOCKER_IMAGE="pavics/workflow-tests:210201.2"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210126"
+    DOCKER_IMAGE="pavics/workflow-tests:210201"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210126"
+    DOCKER_IMAGE="pavics/workflow-tests:210201"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210201"
+    DOCKER_IMAGE="pavics/workflow-tests:210201.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:201214"
+    DOCKER_IMAGE="pavics/workflow-tests:210126"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210201.1"
+    DOCKER_IMAGE="pavics/workflow-tests:210201.2"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
* Added RavenPy and it's extra dependencies, causing python to downgrade from `3.8` to `3.7`
* Pin OWSLib for timeout bug
* Pin JupyterLab because latest version breaks the JupyterLab extensions we use
* Pin Cftime because it breaks Xarray

For matching PR that deploys this into PAVICS https://github.com/bird-house/birdhouse-deploy/pull/121

Relevant changes:
```diff
# python downgrade most likely due to addition of RavenPy
<   - python=3.8.6=h852b56e_0_cpython
>   - python=3.7.9=hffdb5ce_0_cpython

>     - ravenpy==0.2.3    

>   - statsmodels=0.12.1=py37h902c9e0_2

<   - xclim=0.22.0=pyhd8ed1ab_0
>   - xclim=0.23.0=pyhd8ed1ab_0

<     - birdhouse-birdy==0.6.9
>     - birdhouse-birdy==0.7.0


<   - cf_xarray=0.3.1=pyhd3deb0d_0
>   - cf_xarray=0.4.0=pyh44b312d_0

<   - clisops=0.4.0=pyhd3deb0d_0
>   - clisops=0.5.1=pyhd3deb0d_0

<   - dask=2020.12.0=pyhd8ed1ab_0
>   - dask=2021.1.1=pyhd8ed1ab_0

<   - hvplot=0.6.0=pyh9f0ad1d_0
>   - hvplot=0.7.0=pyhd3deb0d_0

<   - jupyter_server=1.0.10=py38h578d9bd_0
>   - jupyter_server=1.2.3=py37h89c1867_1
```

Full diff of `conda env export`:
[201214-210201.2-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5908217/201214-210201.2-conda-env-export.diff.txt)

Full new `conda env export`: 
[210201.2-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/5908220/210201.2-conda-env-export.yml.txt)
