### PR TITLE
docker: add xESMF to Jupyter env

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210201.2"
+            image "pavics/workflow-tests:210216"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210201.2
+FROM pavics/workflow-tests:210216
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,13 +23,6 @@ RUN umask 0000 && conda env create -f /environment.yml
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 
-# TODO: remove this hacked pin.  Should pin in environment.yml instead.
-# Added this pin here to not have to rebuild the gigantic `conda env create`
-# layer and also invalidate the layer below to force get latest ravenpy 0.2.3.
-# Pins cftime >= 1.2 < 1.4. Because 1.4 breaks xarray (pydata/xarray#4853).
-# https://github.com/Ouranosinc/xclim/pull/641
-RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy cftime==1.3.1
-
 # our notebooks are hardcoded to lookup for kernel named 'birdy'
 # this python is from the birdy env above
 # Make, g++ and libnetcdf-dev needed for ravenpy install using --install-option.

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -48,6 +48,9 @@ dependencies:
   - nc-time-axis
   - statsmodels  # for ravenpy
   - xclim
+  # Universal Regridder for Geospatial Data
+  # https://github.com/pangeo-data/xESMF
+  - xesmf
   # https://anaconda.org/anaconda/memory_profiler
   # Monitor memory consumption of a process as well as line-by-line analysis
   # of memory consumption for Python programs.

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -11,9 +11,7 @@ dependencies:
   - xarray
   - numpy
 #  - birdy
-  # avoid owslib 0.22 with timeout bug
-  # https://github.com/geopython/OWSLib/issues/737
-  - owslib==0.21.0
+  - owslib>=0.23.0
   - netcdf4
   # https://github.com/ecmwf/cfgrib
   # Python interface to map GRIB files to the Unidata's Common Data Model v4

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210201.2"
+    DOCKER_IMAGE="pavics/workflow-tests:210216"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210201.2"
+    DOCKER_IMAGE="pavics/workflow-tests:210216"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
For regridding notebook, see https://github.com/Ouranosinc/pavics-sdi/pull/201#issuecomment-778329309.

Also unpin `owslib` (broke xarray) and `cftime` (timeout bug) pinned in previous release (https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/60).

This new Jupyter env is deployed to https://medus.ouranos.ca/jupyter so you can test out xESMF.

Jenkins build with Raven notebooks enabled: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/test-nbval-lax-DO_NOT_MERGE/13/console

That 12 mins 45 sec includes all Raven, Finch and Pavics-sdi notebooks.  It's against my devel server lvupavicsmaster.ouranos.ca since Boreas currently have a performance problem (https://github.com/bird-house/birdhouse-deploy/pull/123) and would take too long to run all Raven notebooks.

Raven failures are known, compared to https://github.com/Ouranosinc/raven/pull/349#pullrequestreview-580492333.

```
12:33:56  =========================== short test summary info ============================
12:33:56  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 8
12:33:56  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 9
12:33:56  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 10
12:33:56  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 11
12:33:56  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 18
12:33:56  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 19
12:33:56  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 20
12:33:56  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 21
12:33:56  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 22
12:33:56  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 1
12:33:56  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 3
12:33:56  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 4
12:33:56  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 5
12:33:56  FAILED raven-master/docs/source/notebooks/Region_selection.ipynb::Cell 7
12:33:56  FAILED raven-master/docs/source/notebooks/Region_selection.ipynb::Cell 8
12:33:56  FAILED raven-master/docs/source/notebooks/Subset_climate_data_over_watershed.ipynb::Cell 5
12:33:56  ============ 16 failed, 234 passed, 2 skipped in 765.72s (0:12:45) =============
```

Jenkins build against prod Boreas: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/test-nbval-lax-DO_NOT_MERGE/15/console (performance problem seems to have improved, not sure what has changed on Prod, the whole testsuite used to take around 30 mins before).

```
16:52:37  =========================== short test summary info ============================
16:52:37  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 8
16:52:37  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 9
16:52:37  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 10
16:52:37  FAILED raven-master/docs/source/notebooks/Bias_correcting_climate_data.ipynb::Cell 11
16:52:37  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 18
16:52:37  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 19
16:52:37  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 20
16:52:37  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 21
16:52:37  FAILED raven-master/docs/source/notebooks/Full_process_example_1.ipynb::Cell 22
16:52:37  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 1
16:52:37  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 3
16:52:37  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 4
16:52:37  FAILED raven-master/docs/source/notebooks/Multiple_watersheds_simulation.ipynb::Cell 5
16:52:37  FAILED raven-master/docs/source/notebooks/Region_selection.ipynb::Cell 7
16:52:37  FAILED raven-master/docs/source/notebooks/Region_selection.ipynb::Cell 8
16:52:37  FAILED raven-master/docs/source/notebooks/Subset_climate_data_over_watershed.ipynb::Cell 5
16:52:37  ============ 16 failed, 234 passed, 2 skipped in 1012.44s (0:16:52) ============
```

Noticeable changes:

```diff
>   - xesmf=0.5.2=pyhd8ed1ab_0

<   - owslib=0.21.0=pyhd8ed1ab_0
>   - owslib=0.23.0=pyhd8ed1ab_0

<   - cftime=1.3.1=py37h6323ea4_0
>   - cftime=1.4.1=py37h902c9e0_0

<   - dask=2021.1.1=pyhd8ed1ab_0
>   - dask=2021.2.0=pyhd8ed1ab_0 

<   - rioxarray=0.1.1=pyhd8ed1ab_0
>   - rioxarray=0.2.0=pyhd8ed1ab_0
```

Full `conda env export` diff:
[210201.2-210216-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6012490/210201.2-210216-conda-env-export.diff.txt)

Full new `conda env export`:
[210216-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6012491/210216-conda-env-export.yml.txt)
