### PR TITLE
Update nbval sanitize config for pavics sdi regridding notebook

### DIFF
--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -102,7 +102,7 @@ replace: /tmpRANDOM/
 [percent-percent-time-output-cpu-times]
 # CPU times: user 4.74 s, sys: 110 ms, total: 4.84 s
 regex: CPU times:\s+user\s+\d+.+\,\s+sys:\s+\d+.+\,\s+total:\s+\d+\.?\d*\s+[a-z]+
-replace: CPU times: NUM s, sys: NUM s, total: NUM s
+replace: CPU times: user NUM s, sys: NUM s, total: NUM s
 
 [percent-percent-time-output-wall-time]
 # Wall time: 4.84 s

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -101,7 +101,7 @@ replace: /tmpRANDOM/
 
 [percent-percent-time-output-cpu-times]
 # CPU times: user 4.74 s, sys: 110 ms, total: 4.84 s
-regex: CPU times:\s+\d+.+\,\s+sys:\s+\d+.+\,\s+total:\s+\d+
+regex: CPU times:\s+user\s+\d+.+\,\s+sys:\s+\d+.+\,\s+total:\s+\d+
 replace: CPU times: NUM s, sys: NUM s, total: NUM s
 
 [percent-percent-time-output-wall-time]

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -101,7 +101,7 @@ replace: /tmpRANDOM/
 
 [percent-percent-time-output-cpu-times]
 # CPU times: user 4.74 s, sys: 110 ms, total: 4.84 s
-regex: CPU times:\s+\d+\.?\d*\s+[a-z]+,\s+sys:\s+\d+\.?\d*\s+[a-z]+,\s+total:\s+\d+\.?\d*\s+[a-z]+
+regex: CPU times:\s+\d+\.?\d*\s+[a-z]+\,\s+sys:\s+\d+\.?\d*\s+[a-z]+\,\s+total:\s+\d+\.?\d*\s+[a-z]+
 replace: CPU times: NUM s, sys: NUM s, total: NUM s
 
 [percent-percent-time-output-wall-time]

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -98,3 +98,13 @@ replace: /tmpRANDOM.png
 # Downloading to /tmp/tmp_v07l0_1/slp.2001_bbox_subset.nc.
 regex: /tmp[a-zA-Z0-9_]{8}/
 replace: /tmpRANDOM/
+
+[percent-percent-time-output-cpu-times]
+# CPU times: user 4.74 s, sys: 110 ms, total: 4.84 s
+regex: CPU times:\s+\d+\.?\d*\s+[a-z]+,\s+sys:\s+\d+\.?\d*\s+[a-z]+,\s+total:\s+\d+\.?\d*\s+[a-z]+
+replace: CPU times: NUM s, sys: NUM s, total: NUM s
+
+[percent-percent-time-output-wall-time]
+# Wall time: 4.84 s
+regex: Wall time:\s+\d+\.?\d*\s+[a-z]+
+replace: Wall time: NUM s

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -101,7 +101,7 @@ replace: /tmpRANDOM/
 
 [percent-percent-time-output-cpu-times]
 # CPU times: user 4.74 s, sys: 110 ms, total: 4.84 s
-regex: CPU times:\s+user\s+\d+.+\,\s+sys:\s+\d+.+\,\s+total:\s+\d+
+regex: CPU times:\s+user\s+\d+.+\,\s+sys:\s+\d+.+\,\s+total:\s+\d+\.?\d*\s+[a-z]+
 replace: CPU times: NUM s, sys: NUM s, total: NUM s
 
 [percent-percent-time-output-wall-time]

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -101,7 +101,7 @@ replace: /tmpRANDOM/
 
 [percent-percent-time-output-cpu-times]
 # CPU times: user 4.74 s, sys: 110 ms, total: 4.84 s
-regex: CPU times:\s+\d+\.?\d*\s+[a-z]+\,\s+sys:\s+\d+\.?\d*\s+[a-z]+\,\s+total:\s+\d+\.?\d*\s+[a-z]+
+regex: CPU times:\s+\d+.+\,\s+sys:\s+\d+.+\,\s+total:\s+\d+
 replace: CPU times: NUM s, sys: NUM s, total: NUM s
 
 [percent-percent-time-output-wall-time]


### PR DESCRIPTION
For this regridding notebook https://github.com/Ouranosinc/pavics-sdi/blob/bbe3061dceb98688e9fd58836fbc50992ee31568/docs/source/notebooks/regridding.ipynb (PR https://github.com/Ouranosinc/pavics-sdi/pull/201) to pass Jenkins.

Double Jenkins run to be sure:
http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/update-nbval-sanitize-config-for-pavics-sdi-regridding-notebook/7/console
http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/update-nbval-sanitize-config-for-pavics-sdi-regridding-notebook/8/console

Jenkins passing also required https://github.com/bird-house/birdhouse-deploy/pull/132 and https://github.com/Ouranosinc/pavics-sdi/pull/206