### PR TITLE
runtest: increase notebook timeout due to heavier new pavics-sdi regridding notebook

### DIFF
--- a/runtest
+++ b/runtest
@@ -51,8 +51,12 @@ if [ x"$SAVE_RESULTING_NOTEBOOK" = xtrue ]; then
             # prevent name clash
             filename="${filename}_`date '+%s'`"
         fi
+        # Timeout must not be more than 240s (4 mins).
+        # Tutorial notebooks should be fast so user do not lose patience waiting
+        # for them to run.  If more than 4 mins, in addition to simplifying the
+        # notebook, should also check machine performance.
         jupyter nbconvert --to notebook --execute \
-            --ExecutePreprocessor.timeout=60 --allow-errors \
+            --ExecutePreprocessor.timeout=240 --allow-errors \
             --output-dir buildout --output "${filename}.output.ipynb" "$nb"
     done
 fi


### PR DESCRIPTION
Also harmonize with the proxy timeout here
https://github.com/bird-house/birdhouse-deploy/blob/7198ee378f6d123922d4b622fea5fb9eeb6743d7/birdhouse/default.env#L55-L57

Will also help for Raven notebooks since these are particularly heavy.