### PR TITLE
Branch chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+## IDEs
+.idea
+.vscode
+
 # vim temp files
 *.swp
 

--- a/downloadrepos
+++ b/downloadrepos
@@ -17,7 +17,7 @@ downloadgithubrepos() {
     # clean up other previously downloaded branches of the same repo as well
     rm -rf ${repo_name}-*
     ls | grep $repo_name
-    downloadrepos https://github.com/$repo_owner/$repo_name $repo_branch
+    downloadrepos https://github.com/$repo_owner/$repo_name "$repo_branch"
     ls | grep $repo_name
     set +x
 }

--- a/testall
+++ b/testall
@@ -22,6 +22,12 @@ RAVEN_REPO_NAME="`echo "$RAVEN_REPO" | sed "s@^.*/@@g"`"
 ESGF_COMPUTE_API_BRANCH="`echo "$ESGF_COMPUTE_API_BRANCH" | sed "s@/@-@g"`"
 ESGF_COMPUTE_API_REPO_NAME="`echo "$ESGF_COMPUTE_API_REPO" | sed "s@^.*/@@g"`"
 
+# branches that have allowed characters such as '+' other than alphanum, '-' and '_' are converted to '-' in archives
+PAVICS_SDI_DIR=`echo "${PAVICS_SDI_REPO_NAME}-${PAVICS_SDI_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
+FINCH_DIR=`echo "${FINCH_REPO_NAME}-${FINCH_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
+RAVEN_DIR=`echo "${RAVEN_REPO_NAME}-${RAVEN_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
+ESGF_COMPUTE_API_DIR=`echo "${ESGF_COMPUTE_API_REPO_NAME}-${ESGF_COMPUTE_API_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
+
 # lowercase VERIFY_SSL string
 VERIFY_SSL="`echo "$VERIFY_SSL" | tr '[:upper:]' '[:lower:]'`"
 if [ x"$VERIFY_SSL" = xfalse ]; then
@@ -47,16 +53,16 @@ TEST_ESGF_COMPUTE_API_REPO="`echo "$TEST_ESGF_COMPUTE_API_REPO" | tr '[:upper:]'
 
 NOTEBOOKS_TO_TEST="notebooks/*.ipynb"
 if [ x"$TEST_PAVICS_SDI_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $PAVICS_SDI_REPO_NAME-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb"
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${PAVICS_SDI_DIR}/docs/source/notebooks/*.ipynb"
 fi
 if [ x"$TEST_FINCH_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $FINCH_REPO_NAME-$FINCH_BRANCH/docs/source/notebooks/*.ipynb"
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${FINCH_DIR}/docs/source/notebooks/*.ipynb"
 fi
 if [ x"$TEST_RAVEN_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $RAVEN_REPO_NAME-$RAVEN_BRANCH/docs/source/notebooks/*.ipynb"
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${RAVEN_DIR}/docs/source/notebooks/*.ipynb"
 fi
 if [ x"$TEST_ESGF_COMPUTE_API_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $ESGF_COMPUTE_API_REPO_NAME-$ESGF_COMPUTE_API_BRANCH/examples/*.ipynb"
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${ESGF_COMPUTE_API_DIR}/examples/*.ipynb"
 fi
 
 # last notebooks higher chance for name clash


### PR DESCRIPTION
I created that branch and found out that notebooks were not found: 
https://github.com/Ouranosinc/pavics-sdi/tree/magpie-thredds+catalog-deprecate

Seems like archives replace everything else than alphanum and `-`, `_` to `-`, but still use the original chars (eg `+` in this case) for the URL reference. 

This PR replaces where necessary.
