### PR TITLE
jenkins: set TEST_MAGPIE_AUTH default value to false

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
         //   The script attempts to remove everything, but could be incapable of doing so if Magpie become inaccessible
         //   midway during execution. Employed users/groups are not critical (not modifying existing users permissions),
         //   but could 'pollute' the user list over time.
-        booleanParam(name: 'TEST_MAGPIE_AUTH', defaultValue: true,
+        booleanParam(name: 'TEST_MAGPIE_AUTH', defaultValue: false,
                      description: '''Check the box to test Authentication/Authorization using Magpie/Twitcher services.
 Note: This test suite might require manual clean-up on failure (if critical error).
                      ''')


### PR DESCRIPTION
It was agreed the default value was supposed to be `false` in comment
https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/55#issuecomment-736128455.

Another reason to keep this option to `false` by default, is this entire
Jenkins test suite also runs nightly on production instances so the admin
password on production instances will never be the default value, for security
reason, so this new notebook activated by `TEST_MAGPIE_AUTH` will never pass.