### PR TITLE
Jenkins: allow to customize py.test options for --nbval-lax and a few other minor fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,8 @@ Note: This test suite might require manual clean-up on failure (if critical erro
                description: 'ESGF_COMPUTE_API_REPO branch to test against.', trim: true)
         string(name: 'ESGF_COMPUTE_API_REPO', defaultValue: 'ESGF/esgf-compute-api',
                description: 'https://github.com/ESGF/esgf-compute-api repo or fork to test against.', trim: true)
+        string(name: 'PYTEST_EXTRA_OPTS', defaultValue: '',
+               description: 'Extra options to pass to pytest', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                      description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ Note: This test suite might require manual clean-up on failure (if critical erro
         string(name: 'ESGF_COMPUTE_API_REPO', defaultValue: 'ESGF/esgf-compute-api',
                description: 'https://github.com/ESGF/esgf-compute-api repo or fork to test against.', trim: true)
         string(name: 'PYTEST_EXTRA_OPTS', defaultValue: '',
-               description: 'Extra options to pass to pytest', trim: true)
+               description: 'Extra options to pass to pytest, ex: --nbval-lax', trim: true)
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                      description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ cloud to test out all the notebooks in this test suite.
 # this assume the PAVICS host hardcoded inside the notebooks is pavics.ouranos.ca
 PAVICS_HOST=host.example.com ./runtest
 
+# provide more cli options to py.test
+PYTEST_EXTRA_OPTS="--nbval-lax" ./runtest
+
 # disable SSL cert verification for notebooks that support this flag
 # useful together with PAVICS_HOST to hit hosts using self-signed SSL cert
 DISABLE_VERIFY_SSL=1 ./runtest

--- a/launchcontainer
+++ b/launchcontainer
@@ -13,7 +13,7 @@ GID="`id -g`"
 
 # launch with current user UID and GID to not have write permission problems
 docker run -it --rm --name $CONTAINER_NAME \
-    -v `pwd`:`pwd` -u 0:0 -w `pwd` \
+    -v `pwd`:`pwd` -u 0:0 -w `pwd` --hostname `hostname -f` \
     $DOCKER_RUN_OPTS \
     $DOCKER_IMAGE \
     bash -c "groupmod -g $GID jenkins; \

--- a/launchnotebook
+++ b/launchnotebook
@@ -19,7 +19,7 @@ GID="`id -g`"
 
 # launch with current user UID and GID to not have write permission problems
 docker run --rm --name $CONTAINER_NAME \
-    -p $PORT:$PORT -u 0:0 -v `pwd`:`pwd` \
+    -p $PORT:$PORT -u 0:0 -v `pwd`:`pwd` --hostname `hostname -f` \
     $DOCKER_RUN_OPTS \
     $DOCKER_IMAGE \
     bash -c "groupmod -g $GID jenkins; \

--- a/runtest
+++ b/runtest
@@ -26,7 +26,7 @@ fi
 # so tests still pass when user want to disable ssl cert verification
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
-py.test --nbval $NOTEBOOKS --sanitize-with notebooks/output-sanitize.cfg
+py.test --nbval $NOTEBOOKS --sanitize-with notebooks/output-sanitize.cfg $PYTEST_EXTRA_OPTS
 EXIT_CODE="$?"
 
 # lowercase SAVE_RESULTING_NOTEBOOK string

--- a/testall
+++ b/testall
@@ -23,10 +23,10 @@ ESGF_COMPUTE_API_BRANCH="`echo "$ESGF_COMPUTE_API_BRANCH" | sed "s@/@-@g"`"
 ESGF_COMPUTE_API_REPO_NAME="`echo "$ESGF_COMPUTE_API_REPO" | sed "s@^.*/@@g"`"
 
 # branches that have allowed characters such as '+' other than alphanum, '-' and '_' are converted to '-' in archives
-PAVICS_SDI_DIR=`echo "${PAVICS_SDI_REPO_NAME}-${PAVICS_SDI_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
-FINCH_DIR=`echo "${FINCH_REPO_NAME}-${FINCH_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
-RAVEN_DIR=`echo "${RAVEN_REPO_NAME}-${RAVEN_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
-ESGF_COMPUTE_API_DIR=`echo "${ESGF_COMPUTE_API_REPO_NAME}-${ESGF_COMPUTE_API_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
+PAVICS_SDI_DIR=`echo "${PAVICS_SDI_REPO_NAME}-${PAVICS_SDI_BRANCH}" | sed "s@[^a-zA-Z0-9_\-\.]@-@g"`
+FINCH_DIR=`echo "${FINCH_REPO_NAME}-${FINCH_BRANCH}" | sed "s@[^a-zA-Z0-9_\-\.]@-@g"`
+RAVEN_DIR=`echo "${RAVEN_REPO_NAME}-${RAVEN_BRANCH}" | sed "s@[^a-zA-Z0-9_\-\.]@-@g"`
+ESGF_COMPUTE_API_DIR=`echo "${ESGF_COMPUTE_API_REPO_NAME}-${ESGF_COMPUTE_API_BRANCH}" | sed "s@[^a-zA-Z0-9_\-\.]@-@g"`
 
 # lowercase VERIFY_SSL string
 VERIFY_SSL="`echo "$VERIFY_SSL" | tr '[:upper:]' '[:lower:]'`"

--- a/testall
+++ b/testall
@@ -23,10 +23,10 @@ ESGF_COMPUTE_API_BRANCH="`echo "$ESGF_COMPUTE_API_BRANCH" | sed "s@/@-@g"`"
 ESGF_COMPUTE_API_REPO_NAME="`echo "$ESGF_COMPUTE_API_REPO" | sed "s@^.*/@@g"`"
 
 # branches that have allowed characters such as '+' other than alphanum, '-' and '_' are converted to '-' in archives
-PAVICS_SDI_DIR=`echo "${PAVICS_SDI_REPO_NAME}-${PAVICS_SDI_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
-FINCH_DIR=`echo "${FINCH_REPO_NAME}-${FINCH_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
-RAVEN_DIR=`echo "${RAVEN_REPO_NAME}-${RAVEN_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
-ESGF_COMPUTE_API_DIR=`echo "${ESGF_COMPUTE_API_REPO_NAME}-${ESGF_COMPUTE_API_BRANCH}" | sed "s@[^a-zA-Z0-9_-]@-@g"`
+PAVICS_SDI_DIR=`echo "${PAVICS_SDI_REPO_NAME}-${PAVICS_SDI_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
+FINCH_DIR=`echo "${FINCH_REPO_NAME}-${FINCH_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
+RAVEN_DIR=`echo "${RAVEN_REPO_NAME}-${RAVEN_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
+ESGF_COMPUTE_API_DIR=`echo "${ESGF_COMPUTE_API_REPO_NAME}-${ESGF_COMPUTE_API_BRANCH}" | sed "s@[^a-zA-Z0-9_-\.]@-@g"`
 
 # lowercase VERIFY_SSL string
 VERIFY_SSL="`echo "$VERIFY_SSL" | tr '[:upper:]' '[:lower:]'`"


### PR DESCRIPTION
@huard we will be able to optionally provide `--nbval-lax` for Raven notebooks (will help for the up-coming Raven demo).

@MatProv I kept it a text box so we have the flexibility to add other `py.test` options later without having to modify the Jenkins UI again.

@fmigneault Your previous Branch chars PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/65, the `.` (dot) was also not replaced in the archive dir name.  Also had to escape the `-` since it is the "range" operator.

Tested here https://daccs-jenkins.crim.ca/job/PAVICS-e2e-workflow-tests/job/minor-fixes-launchnotebook-nbval-lax-as-option/2/parameters/ (using pavics-sdi branch `lvu-test.branch.name.with-dots` and activating Raven notebooks with `--nbval-lax`, targetting my lvupavicsdev.ouranos.ca with latest Finch and Raven).

For the `launchnotebook` and `launchcontainer` script, see commit description of https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/commit/ee6af8c87389876e521816b6f2f74e3df83ac09b for the reason.