### PR TITLE
docker: rebuild to get latest RavenPy for Raven demo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210408"
+            image "pavics/workflow-tests:210414"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210408
+FROM pavics/workflow-tests:210414
 
 USER root
 

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210408"
+    DOCKER_IMAGE="pavics/workflow-tests:210414"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210408"
+    DOCKER_IMAGE="pavics/workflow-tests:210414"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
Matching PR to deploy to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/147

Jenkins all passed http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-for-raven-notebooks-demo/4/console (together with the new finch in the birdhouse-deploy PR above).

Relevant changes:

```diff
<   - ravenpy=0.3.1=py37_0
>   - ravenpy=0.4.1=py37_0

<   - xesmf=0.5.2=pyhd8ed1ab_0
>   - xesmf=0.5.3=pyhd8ed1ab_0 

<   - dash=1.19.0=pyhd8ed1ab_0
>   - dash=1.20.0=pyhd8ed1ab_0
```

Full diff of `conda env export`:
[210408-210414-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6312821/210408-210414-conda-env-export.diff.txt)

Full new `conda env export`:
[210414-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6312824/210414-conda-env-export.yml.txt)

