### PR TITLE
Nbval default ignore html and javascript output

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,3 @@
 def pytest_collectstart(collector):
-    collector.skip_compare += 'text/html', 'application/javascript',
+    if collector.fspath and collector.fspath.ext == '.ipynb':
+        collector.skip_compare += 'text/html', 'application/javascript',

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,2 @@
+def pytest_collectstart(collector):
+    collector.skip_compare += 'text/html', 'application/javascript',


### PR DESCRIPTION
# Overview

Ignore by default html and javascript output to decrease usage of `NBVAL_IGNORE_OUTPUT`.

## Changes

- Adds `conftest.py` following https://nbval.readthedocs.io/en/latest/index.html?highlight=skip#Skipping-certain-output-types

## Related Issue / Discussion

- Probably will avoid us needing `--nbval-lax`.
- Tested with Raven notebooks http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/nbval-default-ignore-html-and-javascript-output/2/console all diff from xarray html output are gone

## Additional Information

Nbval documentation was not 100% correct: https://github.com/computationalmodelling/nbval/issues/168