### PR TITLE
New docker build for ravenpy birdy xclim

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210525"
+            image "pavics/workflow-tests:210526"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210527"
+            image "pavics/workflow-tests:210527.1"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210527.1"
+            image "pavics/workflow-tests:210527.1-update20210615"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210415"
+            image "pavics/workflow-tests:210525"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210526"
+            image "pavics/workflow-tests:210527"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210526
+FROM pavics/workflow-tests:210527
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210525
+FROM pavics/workflow-tests:210526
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210527.1
+FROM pavics/workflow-tests:210527.1-update20210615
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210415
+FROM pavics/workflow-tests:210525
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210527
+FROM pavics/workflow-tests:210527.1
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN python -m ipykernel install --name birdy
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
 # environment.yml above
-# RUN conda install -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy nbdime
+# RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 RUN jupyter lab build

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,6 +1,6 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:210415
+FROM pavics/workflow-tests:210527.1
 
 USER root
 
@@ -12,7 +12,7 @@ USER root
 #    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy rasterio=1.2.1
+    && conda update -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy xclim
 
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,6 +1,6 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:210525
+FROM pavics/workflow-tests:210527.1
 
 USER root
 
@@ -12,9 +12,9 @@ USER root
 #    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy pydantic
+    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy rasterio=1.2.2
 
-RUN umask 0000 \
-    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip
+#RUN umask 0000 \
+#    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip
 
 USER jenkins

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -12,7 +12,8 @@ USER root
 #    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda update -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy xclim
+    && conda update -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy xclim \
+    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy intake intake-esm gcsfs zarr
 
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,0 +1,17 @@
+# For testing quickly without having to do a full rebuild.
+
+FROM pavics/workflow-tests:210525
+
+USER root
+
+# Use 'update' for existing and 'install' for new package.
+# Keep same channel ordering to not revert anything.
+#RUN umask 0000 \
+#    && conda update -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy clisops xclim \
+#    && pip uninstall -y ravenpy \
+#    && conda install -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
+
+RUN umask 0000 \
+    && conda install -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy pydantic
+
+USER jenkins

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,6 +1,6 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:210527.1
+FROM pavics/workflow-tests:210415
 
 USER root
 
@@ -12,7 +12,7 @@ USER root
 #    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy rasterio=1.2.2
+    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy rasterio=1.2.1
 
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -7,12 +7,12 @@ USER root
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
 #RUN umask 0000 \
-#    && conda update -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy clisops xclim \
+#    && conda update -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy clisops xclim \
 #    && pip uninstall -y ravenpy \
-#    && conda install -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
+#    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda install -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy pydantic
+    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy pydantic
 
 RUN umask 0000 \
     && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -14,4 +14,7 @@ USER root
 RUN umask 0000 \
     && conda install -c zeitsperre -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy pydantic
 
+RUN umask 0000 \
+    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip
+
 USER jenkins

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -1,7 +1,6 @@
 # conda env create -f environment.yml
 name: birdy
 channels:
-  - zeitsperre  # for ravenpy
   - conda-forge
   - cdat
   - bokeh

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -44,6 +44,8 @@ dependencies:
   # pinning hvplot did not solve the problem with violin plot.
   - hvplot
   - nc-time-axis
+  # Pin cftime because of https://github.com/SciTools/nc-time-axis/issues/58
+  - cftime==1.4.1
   - statsmodels  # for ravenpy
   # for error 'ImportError: HTTPFileSystem requires "requests" and "aiohttp" to
   # be installed' with call 'fsspec.filesystem('https')'

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -51,6 +51,10 @@ dependencies:
   # be installed' with call 'fsspec.filesystem('https')'
   - aiohttp
   - pydantic
+  - intake
+  - intake-esm
+  - gcsfs
+  - zarr
   - xclim
   - ravenpy
   # Universal Regridder for Geospatial Data

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -49,6 +49,7 @@ dependencies:
   # for error 'ImportError: HTTPFileSystem requires "requests" and "aiohttp" to
   # be installed' with call 'fsspec.filesystem('https')'
   - aiohttp
+  - pydantic
   - xclim
   - ravenpy
   # Universal Regridder for Geospatial Data

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210415"
+    DOCKER_IMAGE="pavics/workflow-tests:210525"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210525"
+    DOCKER_IMAGE="pavics/workflow-tests:210526"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210527"
+    DOCKER_IMAGE="pavics/workflow-tests:210527.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210526"
+    DOCKER_IMAGE="pavics/workflow-tests:210527"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210527.1"
+    DOCKER_IMAGE="pavics/workflow-tests:210527.1-update20210615"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210525"
+    DOCKER_IMAGE="pavics/workflow-tests:210526"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210415"
+    DOCKER_IMAGE="pavics/workflow-tests:210525"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210527"
+    DOCKER_IMAGE="pavics/workflow-tests:210527.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210526"
+    DOCKER_IMAGE="pavics/workflow-tests:210527"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210527.1"
+    DOCKER_IMAGE="pavics/workflow-tests:210527.1-update20210615"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
# Overview

New Jupyter env to get latest of everything, including ravenpy, birdy, xclim.

Jenkins build passing with updated Finch and Pavics-sdi notebooks: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-for-ravenpy/25/

Matching Finch notebook PR: https://github.com/bird-house/finch/pull/188
Matching Pavics-sdi notebook PR: https://github.com/Ouranosinc/pavics-sdi/pull/222
Matching PR to deploy this Jupyter env to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/175

Matching Raven notebook failure found https://github.com/Ouranosinc/raven/issues/392 (http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-for-ravenpy/14/console) and matching fix PR https://github.com/Ouranosinc/raven/pull/393 (http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-for-ravenpy/24/).

Also added new libraries for upcoming Raven notebooks (fixes https://github.com/Ouranosinc/raven/issues/394).

Pavics-landing homepage notebooks manually tested by @tlogan2000 

Deployed to staging env for manual testing: https://medus.ouranos.ca/jupyter/

Also added a way to quickly test a new package without having to do a full rebuild.

## Changes

```diff
<   - ravenpy=0.4.2=py37_1
>   - ravenpy=0.5.2=pyh7f9bfb9_0

# Renamed.
<   - raven=3.0.4.318=hc9bffa2_2
>   - raven-hydro=3.0.4.322=h516393e_0

<   - ostrich=21.03.16=h2bc3f7f_0
>   - ostrich=21.03.16=h4bd325d_1

<   - xclim=0.25.0=pyhd8ed1ab_0
>   - xclim=0.27.0=pyhd8ed1ab_0

# Old version was from pip.
<     - birdhouse-birdy==0.7.0
>   - birdy=v0.8.0=pyh6c4a22f_0

# Was previously included in another package, now it is standalone.
>   - pydantic=1.8.2=py37h5e8e339_0

# New libs for upcoming Raven notebooks
>   - gcsfs=2021.6.0=pyhd8ed1ab_0
>   - intake=0.6.2=pyhd8ed1ab_0
>   - intake-esm=2021.1.15=pyhd8ed1ab_0
>   - zarr=2.8.3=pyhd8ed1ab_0

<   - xarray=0.17.0=pyhd8ed1ab_0
>   - xarray=0.18.2=pyhd8ed1ab_0

<   - owslib=0.23.0=pyhd8ed1ab_0
>   - owslib=0.24.1=pyhd8ed1ab_0

<   - cf_xarray=0.5.1=pyh44b312d_0
>   - cf_xarray=0.5.2=pyh6c4a22f_0

<   - clisops=0.6.3=pyh44b312d_0
>   - clisops=0.6.5=pyh6c4a22f_0

<   - dask=2021.2.0=pyhd8ed1ab_0
>   - dask=2021.6.0=pyhd8ed1ab_0

# Downgrade !
<   - gdal=3.2.1=py37hc5bc4e4_7
>   - gdal=3.1.4=py37h2ec2946_8

# Downgrade !
<   - rasterio=1.2.2=py37hd5c4cce_0
>   - rasterio=1.2.1=py37ha549118_0

<   - hvplot=0.7.1=pyh44b312d_0
>   - hvplot=0.7.2=pyh6c4a22f_0

<   - rioxarray=0.3.1=pyhd8ed1ab_0
>   - rioxarray=0.4.1.post0=pyhd8ed1ab_0

# Downgrade !
<   - xskillscore=0.0.19=pyhd8ed1ab_0                                                                                                                 
>   - xskillscore=0.0.18=py_1
```

Full diff of `conda env export`:
[210415-210527.1-update210615-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6658638/210415-210527.1-update210615-conda-env-export.diff.txt)

Full new `conda env export`:
[210527.1-update210615-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6658646/210527.1-update210615-conda-env-export.yml.txt)

