### PR TITLE
New docker build for raven notebooks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210527.1-update20210615"
+            image "pavics/workflow-tests:210527.1-update20210618"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210527.1-update20210615
+FROM pavics/workflow-tests:210527.1-update20210618
 
 USER root
 

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,6 +1,6 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:210527.1
+FROM pavics/workflow-tests:210527.1-update20210615
 
 USER root
 
@@ -12,8 +12,7 @@ USER root
 #    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda update -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy xclim \
-    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy intake intake-esm gcsfs zarr
+    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy intake-xarray
 
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -12,7 +12,7 @@ USER root
 #    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy intake-xarray
+    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy intake-xarray intake-geopandas intake-stac intake-thredds
 
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -12,7 +12,7 @@ USER root
 #    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 RUN umask 0000 \
-    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy intake-xarray intake-geopandas intake-stac intake-thredds
+    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy intake-xarray intake-geopandas intake-thredds
 
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -65,8 +65,6 @@ dependencies:
   # geopandas (geojson, postgis, shapefile, spatialite) and regionmask for
   # opening shapefiles into regionmask.
   - intake-geopandas
-  # Intake Driver for SpatioTemporal Asset Catalogs (STAC).
-  - intake-stac
   # Intake interface to THREDDS data catalogs (thredds_cat, thredds_merged_source)
   - intake-thredds
   - gcsfs

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -61,6 +61,14 @@ dependencies:
   # load netCDF, Zarr and other multi-dimensional data (xarray_image, netcdf,
   # grib, opendap, rasterio, remote-xarray, zarr)
   - intake-xarray
+  # load from ESRI Shape Files, GeoJSON, and geospatial databases with
+  # geopandas (geojson, postgis, shapefile, spatialite) and regionmask for
+  # opening shapefiles into regionmask.
+  - intake-geopandas
+  # Intake Driver for SpatioTemporal Asset Catalogs (STAC).
+  - intake-stac
+  # Intake interface to THREDDS data catalogs (thredds_cat, thredds_merged_source)
+  - intake-thredds
   - gcsfs
   - zarr
   - xclim

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -51,8 +51,16 @@ dependencies:
   # be installed' with call 'fsspec.filesystem('https')'
   - aiohttp
   - pydantic
+  # Intake is a lightweight set of tools for loading and sharing data in data science projects
   - intake
+  # https://intake.readthedocs.io/en/latest/plugin-directory.html
+  # Plugin for building and loading intake catalogs for earth system data sets
+  # holdings, such as CMIP (Coupled Model Intercomparison Project) and CESM
+  # Large Ensemble datasets.
   - intake-esm
+  # load netCDF, Zarr and other multi-dimensional data (xarray_image, netcdf,
+  # grib, opendap, rasterio, remote-xarray, zarr)
+  - intake-xarray
   - gcsfs
   - zarr
   - xclim

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210527.1-update20210615"
+    DOCKER_IMAGE="pavics/workflow-tests:210527.1-update20210618"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210527.1-update20210615"
+    DOCKER_IMAGE="pavics/workflow-tests:210527.1-update20210618"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/releasedocker
+++ b/releasedocker
@@ -3,6 +3,21 @@
 OLD_VER="$1"; shift
 NEW_VER="$1"; shift
 
+TAG_PREFIX="docker"
+if [ -n "$RELEASEDOCKER_IS_UPDATE" ]; then
+    # "update" release makes it faster to build and release and also allow us
+    # sort of pin the entire existing working environment if we foresee many
+    # disruptive updates ahead and we are not ready to absorb them.
+
+    # Basically allowing us to still release new key components without being
+    # impacted by other changing components that we are not ready to deal with.
+
+    # Full and clean release are much prefered so this is to be used in last
+    # resort only, do not abuse.
+
+    TAG_PREFIX="dockerupdate"
+fi
+
 update_ver() {
     FILE="$1"
     sed -i "s@pavics/workflow-tests:$OLD_VER@pavics/workflow-tests:$NEW_VER@g" $FILE
@@ -19,8 +34,10 @@ echo "Looks good to commit? (Ctrl-C to abort)"; read a
 
 git ci -m "release: update to use image pavics/workflow-tests:$NEW_VER"
 git show
-echo "Looks good to tag and push? (Ctrl-C to abort)"; read a
+echo "Looks good to tag? (Ctrl-C to abort)"; read a
 
-git tag docker-$NEW_VER
+git tag ${TAG_PREFIX}-${NEW_VER}
+echo "Tag is good to push? (Ctrl-C to abort)"; read a
+
 git push
 git push --tags


### PR DESCRIPTION
Add `intake-xarray` (fixes https://github.com/Ouranosinc/pavics-sdi/issues/223)

@huard @tlogan2000 also proactively add `intake-geopandas` and `intake-thredds` as they look interesting.  Tried to add `intake-stac` but got into conflicting dependencies during build so had to leave it out.

This is an incremental build (not a full build) from the previous release (https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/75) so only those are changed (so regression risk is extremely low):
```
    package                    |            build                                                                                                     
    ---------------------------|-----------------                                                                                                     
    intake-geopandas-0.2.4     |     pyhd8ed1ab_0          12 KB  conda-forge                                                                         
    intake-thredds-2021.6.16   |     pyhd8ed1ab_0          13 KB  conda-forge                                                                         
    intake-xarray-0.5.0        |     pyhd8ed1ab_0         1.4 MB  conda-forge                                                                         
    ------------------------------------------------------------
```

Jenkins build with only known error: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-raven-notebooks/1/console

Raven notebooks passing: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build-raven-notebooks/2/console

Manual tested Pavics homepage notebooks as well, using https://medus.ouranos.ca/jupyter since this image is deployed there.

Matching PR to deploy to PAVICS https://github.com/bird-house/birdhouse-deploy/pull/178
