### PR TITLE
docker: update to JupyterLab v3 and fix broken jupyterlab-system-monitor plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:210723"
+            image "pavics/workflow-tests:210728"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:210723
+FROM pavics/workflow-tests:210728
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,6 @@ RUN jupyter lab build
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
-    && jupyter labextension install @pyviz/jupyterlab_pyviz \
     && jupyter labextension install @jupyterlab/debugger \
     && jupyter labextension install @jupyterlab/google-drive \
     && jupyter labextension install jupyterlab-topbar-text \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,6 @@ RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
     && jupyter labextension install @jupyterlab/debugger \
-    && jupyter labextension install @jupyterlab/google-drive \
     && jupyter labextension install jupyterlab-topbar-text \
                                     jupyterlab_conda
 #    && jupyter labextension install jupyterlab-clipboard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,11 +44,7 @@ RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter labextension install @pyviz/jupyterlab_pyviz \
     && jupyter labextension install @jupyterlab/debugger \
     && jupyter labextension install @jupyterlab/google-drive \
-    && jupyter labextension install jupyterlab-topbar-extension \
-                                    jupyterlab-system-monitor \
-                                    jupyterlab-topbar-text \
-                                    jupyterlab-logout \
-                                    jupyterlab-theme-toggle \
+    && jupyter labextension install jupyterlab-topbar-text \
                                     jupyterlab_conda
 #    && jupyter labextension install jupyterlab-clipboard
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,8 @@ RUN jupyter lab build
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
-    && jupyter labextension install jupyterlab-topbar-text
+    && jupyter labextension install jupyterlab-topbar-text \
+                                    jupyterlab-theme-toggle
 #    && jupyter labextension install jupyterlab-clipboard
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,6 @@ RUN jupyter lab build
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
-    && jupyter labextension install @bokeh/jupyter_bokeh \
     && jupyter labextension install @pyviz/jupyterlab_pyviz \
     && jupyter labextension install @jupyterlab/debugger \
     && jupyter labextension install @jupyterlab/google-drive \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,8 +41,7 @@ RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
     && jupyter labextension install @jupyterlab/debugger \
-    && jupyter labextension install jupyterlab-topbar-text \
-                                    jupyterlab_conda
+    && jupyter labextension install jupyterlab-topbar-text
 #    && jupyter labextension install jupyterlab-clipboard
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,6 @@ RUN jupyter lab build
 RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
     && jupyter serverextension enable voila --sys-prefix \
     && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
-    && jupyter labextension install @jupyterlab/debugger \
     && jupyter labextension install jupyterlab-topbar-text
 #    && jupyter labextension install jupyterlab-clipboard
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -101,8 +101,6 @@ dependencies:
   - jupytext
   # jupyterlab extension for git
   - jupyterlab-git
-  # jupyterlab extension for conda
-  - jupyter_conda
   # Voila turns Jupyter notebooks into standalone web applications
   - voila
   - jupyter-archive

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -35,6 +35,8 @@ dependencies:
   - pscript
   - h5netcdf
   - panel
+  # https://github.com/holoviz/panel
+  - pyviz_comms
   - holoviews
   - geoviews
   # this might still be relevant https://github.com/holoviz/hvplot/issues/498

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -104,6 +104,8 @@ dependencies:
   # Voila turns Jupyter notebooks into standalone web applications
   - voila
   - jupyter-archive
+  # https://github.com/jtpio/jupyterlab-topbar
+  - jupyterlab-topbar
   # xeus-python: back-end kernel implementing the Jupyter Debug Protocol
   - xeus-python
   - jupyter-dash

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -132,6 +132,8 @@ dependencies:
     # https://github.com/ShopRunner/jupyter-notify
     # Jupyter Magic For Browser Notifications of Cell Completion.
     - jupyternotify
+    # https://github.com/jupyterlab-contrib/jupyterlab-logout (was from jupyterlab-topbar)
+    - jupyterlab-logout
     # Needed to run notebook tests.  Missing indirect recursive dependencies
     # somewhere, should not need to manually add it here.
     - pytest-tornasync

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -106,6 +106,10 @@ dependencies:
   - jupyter-archive
   # https://github.com/jtpio/jupyterlab-topbar
   - jupyterlab-topbar
+  # https://github.com/jtpio/jupyterlab-system-monitor (was from jupyterlab-topbar)
+  - jupyterlab-system-monitor
+  - jupyter-resource-usage  # needed by jupyterlab-system-monitor
+  - nbresuse  # needed by jupyterlab-system-monitor
   # xeus-python: back-end kernel implementing the Jupyter Debug Protocol
   - xeus-python
   - jupyter-dash
@@ -128,8 +132,6 @@ dependencies:
     # https://github.com/ShopRunner/jupyter-notify
     # Jupyter Magic For Browser Notifications of Cell Completion.
     - jupyternotify
-    # Needed for https://github.com/jtpio/jupyterlab-topbar
-    - nbresuse
     # Needed to run notebook tests.  Missing indirect recursive dependencies
     # somewhere, should not need to manually add it here.
     - pytest-tornasync

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -93,6 +93,8 @@ dependencies:
   - notebook
   - jupyterlab
   - jupyterhub
+  # https://github.com/mamba-org/gator (was jupyter_conda)
+  - mamba_gator
   # to diff .ipynb files
   - nbdime
   # extension to produce .py files from notebook .ipynb files

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -23,9 +23,7 @@ dependencies:
   - rasterio
   - gdal  # for osgeo
   - geopandas
-  # Pin pandas due to xarray
-  # https://github.com/pydata/xarray/issues/5588#issuecomment-885271773
-  - pandas==1.2.5
+  - pandas
   - rioxarray
   - scikit-image
   - ipyleaflet

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -91,7 +91,7 @@ dependencies:
   - jupyter
   # to be launched by image jupyterhub/jupyterhub
   - notebook
-  - jupyterlab==2.2.9
+  - jupyterlab
   - jupyterhub
   # to diff .ipynb files
   - nbdime

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - h5netcdf
   - panel
   # https://github.com/holoviz/panel
-  - pyviz_comms
+  - pyviz_comms  # (was labextension pyviz/jupyterlab_pyviz in jupyterlab v2)
   - holoviews
   - geoviews
   # this might still be relevant https://github.com/holoviz/hvplot/issues/498

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210723"
+    DOCKER_IMAGE="pavics/workflow-tests:210728"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:210723"
+    DOCKER_IMAGE="pavics/workflow-tests:210728"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
# Overview

JupyterLab v3 was available since January 2021 but we had to pin to v2 since many of the plugins we use were broken at the time for v3.

Fast forward 7 months later, only the Google Drive plugin still do not support JupyterLab v3 so we decided to drop it since it was only used by one single user (`ls -larth  /data/jupyterhub_user_data/*/.home/.jupyter/lab/user-settings/@jupyterlab/google-drive /dev/null` shows who uses it).  We have not enabled the system-wide Google Drive config due to security concern so each user had to configure it themselves separately.

Staying on JupyterLab v2 caused us the reverse problem, some plugins stopped working with v2, example the jupyterlab-system-monitor one.  That one is becoming more crucial as we have more and more users and we would like users to be aware of their resource consumptions on the system.

This PR fixes https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/83, the jupyterlab-system-monitor problem.

## Changes

- Update to JupyterLab v3
- Update install steps for all plugins to be compatible with JupyterLab v3
- Drop Google Drive plugin since not compatible with v3
- Fix jupyterlab-system-monitor plugin, was broken with v2
- Unpin pandas as xarray issue pydata/xarray/issues/5588 fixed
- Picked up latest RavenPy 0.7.0
- Relevant packages changes:
```diff
<   - jupyterlab=2.2.9=pyhd8ed1ab_0
>   - jupyterlab=3.1.0=pyhd8ed1ab_0

<   - jupyterlab_server=1.2.0=py_0
>   - jupyterlab_server=2.6.1=pyhd8ed1ab_0

<   - jupyter-archive=2.2.0=pyhd8ed1ab_0
>   - jupyter-archive=3.0.1=pyhd8ed1ab_0

<   - jupyter_bokeh=2.0.4=pyhd8ed1ab_0
>   - jupyter_bokeh=3.0.2=pyhd8ed1ab_0

<   - jupyterlab-git=0.24.0=pyhd8ed1ab_0
>   - jupyterlab-git=0.31.0=pyhd8ed1ab_0

<   - nbdime=2.1.0=py_0
>   - nbdime=3.1.0=pyhd8ed1ab_0

# Pip to Conda package
<     - nbresuse==0.4.0  
>   - nbresuse=0.4.0=pyhd8ed1ab_0

>   - nbclassic=0.3.1=pyhd8ed1ab_1

>   - jupyterlab-system-monitor=0.8.0=pyhd8ed1ab_1
>   - jupyter-resource-usage=0.5.1=pyhd8ed1ab_0
>   - jupyterlab-topbar=0.6.1=pyhd8ed1ab_2 
>     - jupyterlab-logout=0.5.0

<   - jupyter_conda=5.1.1=hd8ed1ab_0

<   - ravenpy=0.6.0=pyh1bb2064_2
>   - ravenpy=0.7.0=pyh1bb2064_0 

<   - pandas=1.2.5=py37h219a48f_0
>   - pandas=1.3.1=py37h219a48f_0

<   - xarray=0.18.2=pyhd8ed1ab_0
>   - xarray=0.19.0=pyhd8ed1ab_1

<   - dask=2021.7.0=pyhd8ed1ab_0
>   - dask=2021.7.1=pyhd8ed1ab_0

<   - regionmask=0.6.2=pyhd8ed1ab_0
>   - regionmask=0.7.0=pyhd8ed1ab_0
```

## Additional Information

Screenshot showing differences between v2 vs v3 and the working jupyterlab-system-monitor plugin.

![Screenshot from 2021-07-28 14-10-33](https://user-images.githubusercontent.com/11966697/127380391-7f3a6ad4-25c6-4a8b-ac01-8c8d9633d09c.png)

Bokeh and pyviz testing by running `ClimateDataAnalysis-5Visualization.ipynb` on the old and new Jupyter env and manually comparing the graphics generated.  They look similar.

Jenkins build all passed https://daccs-jenkins.crim.ca/job/PAVICS-e2e-workflow-tests/job/update-to-jupyterlab-v3/7/console (CRIM Jenkins)
Notebooks fixes required for the above passing Jenkins build:
* https://github.com/Ouranosinc/pavics-sdi/pull/224
* https://github.com/bird-house/finch/pull/196
* https://github.com/Ouranosinc/PAVICS-landing/pull/30

Jenkins build for Raven nb, all passed: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/update-to-jupyterlab-v3/5/console

Matching PR to deploy this new Jupyter env to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/185

Full diff of `conda env export`:
[210723-210728-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6896271/210723-210728-conda-env-export.diff.txt)

Full new `conda env export`:
[210728-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/6896274/210728-conda-env-export.yml.txt)

