### PR TITLE
Fix runtest to properly exclude regex replace pavics.ouranos.ca string

### DIFF
--- a/runtest
+++ b/runtest
@@ -16,12 +16,11 @@ fi
 
 if [ ! -z "$PAVICS_HOST" ]; then
     echo "Will run notebooks against $PAVICS_HOST"
-    # Any lines marked with TEST_USE_PROD_DATA will replace pavics to boreas to
-    # use data from prod and avoid having to replicate data to test servers.
-    sed -i "/TEST_USE_PROD_DATA/s/pavics.ouranos.ca/boreas.ouranos.ca/g" $NOTEBOOKS
     # .ncml links will always comes from the production server, not the server
     # under test since we do not perform regex replace for .ncml links.
-    sed -i "/\.ncml/!s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS
+    # Any lines marked with TEST_USE_PROD_DATA will replace pavics to boreas to
+    # use data from prod and avoid having to replicate data to test servers.
+    sed -i "/\.ncml|TEST_USE_PROD_DATA/!s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS
     git diff  # not working for notebooks from other repos
 fi
 

--- a/runtest
+++ b/runtest
@@ -16,11 +16,12 @@ fi
 
 if [ ! -z "$PAVICS_HOST" ]; then
     echo "Will run notebooks against $PAVICS_HOST"
-    # .ncml links will always comes from the production server, not the server
+    # * .ncml links will always comes from the production server, not the server
     # under test since we do not perform regex replace for .ncml links.
-    # Any lines marked with TEST_USE_PROD_DATA will replace pavics to boreas to
-    # use data from prod and avoid having to replicate data to test servers.
-    sed -i "/\.ncml|TEST_USE_PROD_DATA/!s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS
+    #
+    # * Any lines marked with TEST_USE_PROD_DATA will also use data from prod
+    # and avoid having to replicate data to test servers.
+    sed -i "/\(\.ncml\|TEST_USE_PROD_DATA\)/!s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS
     git diff  # not working for notebooks from other repos
 fi
 


### PR DESCRIPTION
Current implementation to change `pavics.ouranos.ca` to `boreas.ouranos.ca` was bit silly, done in a haste.

It causes diff problem when the url is printed back.

Relate to PR https://github.com/Ouranosinc/pavics-sdi/pull/225

```
  _ pavics-sdi-fix-subset-user-input.ipynb-for-jenkins/docs/source/notebooks/subset-user-input.ipynb::Cell 12 _
  Notebook cell execution failed
  Cell 12: Cell outputs differ

  Input:
  # gather data from pavics' data catalogue
  catalog = "https://boreas.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml"  # TEST_USE_PROD_DATA

  cat = TDSCatalog(catalog)
  data = cat.datasets[0].access_urls["OPENDAP"]
  data

  Traceback:
   mismatch 'text/plain'

   assert reference_output == test_output failed:

    "'https://pav...rcan_v2.ncml'" == "'https://bor...rcan_v2.ncml'"
    Skipping 72 identical trailing characters in diff, use -v to show
    - 'https://boreas.ouranos
    ?          ^^^^
    + 'https://pavics.ouranos
    ?          ^ +++
```

Jenkins build from CRIM https://daccs-jenkins.crim.ca/job/PAVICS-e2e-workflow-tests/job/fix-runtest-to-not-change-pavics-to-boreas-breaking-some-diffs/2/console

Jenkins build from Ouranos against our staging  server http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/fix-runtest-to-not-change-pavics-to-boreas-breaking-some-diffs/7/console