### PR TITLE
collect missing notebooks artifacts in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,8 +113,14 @@ Note this is another run, will double the time and no guaranty to have same erro
 
     post {
         always {
-            archiveArtifacts(artifacts: 'notebooks/*.ipynb, pavics-sdi-*/docs/source/notebooks/*.ipynb, finch-*/docs/source/notebooks/*.ipynb, raven-*/docs/source/notebooks/*.ipynb, esgf-compute-api-*/examples/*.ipynb, PAVICS-landing-*/content/notebooks/climate_indicators/*.ipynb, buildout/*.output.ipynb, buildout/env-dump/',
-                             fingerprint: true)
+            archiveArtifacts(artifacts: 'notebooks/*.ipynb', fingerprint: true)
+            archiveArtifacts(artifacts: 'pavics-sdi-*/docs/source/**/*.ipynb', fingerprint: true, excludes: 'pavics-sdi-*/docs/source/deprecated/**/*')
+            archiveArtifacts(artifacts: 'finch-*/docs/source/notebooks/*.ipynb', fingerprint: true)
+            archiveArtifacts(artifacts: 'raven-*/docs/source/notebooks/*.ipynb', fingerprint: true)
+            archiveArtifacts(artifacts: 'esgf-compute-api-*/examples/*.ipynb', fingerprint: true)
+            archiveArtifacts(artifacts: 'PAVICS-landing-*/content/notebooks/climate_indicators/*.ipynb', fingerprint: true)
+            archiveArtifacts(artifacts: 'buildout/*.output.ipynb', fingerprint: true)
+            archiveArtifacts(artifacts: 'buildout/env-dump/', fingerprint: true)
         }
 	unsuccessful {  // Run if the current builds status is "Aborted", "Failure" or "Unstable"
             step([$class: 'Mailer', notifyEveryUnstableBuild: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,8 @@ Note this is another run, will double the time and no guaranty to have same erro
     post {
         always {
             archiveArtifacts(artifacts: 'notebooks/*.ipynb', fingerprint: true)
-            archiveArtifacts(artifacts: 'pavics-sdi-*/docs/source/**/*.ipynb', fingerprint: true, excludes: 'pavics-sdi-*/docs/source/deprecated/**/*')
+            archiveArtifacts(artifacts: 'pavics-sdi-*/docs/source/notebooks/*.ipynb', fingerprint: true)
+            archiveArtifacts(artifacts: 'pavics-sdi-*/docs/source/notebook-components/*.ipynb', fingerprint: true)
             archiveArtifacts(artifacts: 'finch-*/docs/source/notebooks/*.ipynb', fingerprint: true)
             archiveArtifacts(artifacts: 'raven-*/docs/source/notebooks/*.ipynb', fingerprint: true)
             archiveArtifacts(artifacts: 'esgf-compute-api-*/examples/*.ipynb', fingerprint: true)


### PR DESCRIPTION
# Overview

Add any variation of sub-dir notebooks for artifact collection in Jenkins.

For instance, following were omitted: 
https://github.com/Ouranosinc/pavics-sdi/tree/master/docs/source/notebook-components

At the same time, ensure following are not matched: 
https://github.com/Ouranosinc/pavics-sdi/tree/master/docs/source/deprecated

## Related Issue / Discussion

Useful for collecting results from https://github.com/bird-house/birdhouse-deploy/pull/114