### PR TITLE
avoid error on missing 'buildout/*.output.ipynb' to archive artifact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,12 @@ Note this is another run, will double the time and no guaranty to have same erro
             archiveArtifacts(artifacts: 'esgf-compute-api-*/examples/*.ipynb', fingerprint: true)
             archiveArtifacts(artifacts: 'PAVICS-landing-*/content/notebooks/climate_indicators/*.ipynb', fingerprint: true)
             archiveArtifacts(artifacts: 'buildout/*.output.ipynb', fingerprint: true)
-            archiveArtifacts(artifacts: 'buildout/env-dump/', fingerprint: true)
+            if (fileExists('buildout/env-dump/')) {
+                archiveArtifacts(artifacts: 'buildout/env-dump/', fingerprint: true)
+            }
+            else {
+                echo "[INFO] No 'buildout/env-dump/' directory to archive artifacts. Skipping it."
+            }
         }
 	unsuccessful {  // Run if the current builds status is "Aborted", "Failure" or "Unstable"
             step([$class: 'Mailer', notifyEveryUnstableBuild: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,13 +120,8 @@ Note this is another run, will double the time and no guaranty to have same erro
             archiveArtifacts(artifacts: 'raven-*/docs/source/notebooks/*.ipynb', fingerprint: true)
             archiveArtifacts(artifacts: 'esgf-compute-api-*/examples/*.ipynb', fingerprint: true)
             archiveArtifacts(artifacts: 'PAVICS-landing-*/content/notebooks/climate_indicators/*.ipynb', fingerprint: true)
-            archiveArtifacts(artifacts: 'buildout/*.output.ipynb', fingerprint: true)
-            if (fileExists('buildout/env-dump/')) {
-                archiveArtifacts(artifacts: 'buildout/env-dump/', fingerprint: true)
-            }
-            else {
-                echo "[INFO] No 'buildout/env-dump/' directory to archive artifacts. Skipping it."
-            }
+            archiveArtifacts(artifacts: 'buildout/*.output.ipynb', fingerprint: true, allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'buildout/env-dump/', fingerprint: true)
         }
 	unsuccessful {  // Run if the current builds status is "Aborted", "Failure" or "Unstable"
             step([$class: 'Mailer', notifyEveryUnstableBuild: false,


### PR DESCRIPTION
## Changes

- Adds check to avoid error on missing `buildout/*.output.ipynb` to archive artifact.

## Related Issue / Discussion

- Resolves https://github.com/bird-house/birdhouse-deploy/pull/220#issuecomment-960345953
- Fix regression from https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/91