### PR TITLE
docker: prevent manual pin of dependencies and improve build speed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220116.1"
+            image "pavics/workflow-tests:220121"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220116"
+            image "pavics/workflow-tests:220116.1"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:211123-update211216"
+            image "pavics/workflow-tests:211221"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:211221"
+            image "pavics/workflow-tests:220116"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220116
+FROM pavics/workflow-tests:220116.1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220116.1
+FROM pavics/workflow-tests:220121
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:211221
+FROM pavics/workflow-tests:220116
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:211123-update211216
+FROM pavics/workflow-tests:211221
 
 USER root
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,4 +2,5 @@ def pytest_collectstart(collector):
     # Make sure ancestor folder name do not end with `.ipynb`, else we have
     # AttributeError: 'Session' object has no attribute 'skip_compare'.
     if collector.fspath and collector.fspath.ext == '.ipynb':
-        collector.skip_compare += 'text/html', 'application/javascript',
+        collector.skip_compare += ('text/html', 'application/javascript',
+                                   'application/vnd.holoviews_load.v0+json',)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN umask 0000 && \
 
 # TODO: put back with previous layer, this one is to make sure we get latest xclim and ravenpy
 RUN umask 0000 && \
-    mamba install --name birdy --channel conda-forge --channel defaults xclim ravenpy
+    mamba update --name birdy --channel conda-forge --channel defaults xclim ravenpy
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM continuumio/miniconda3
 
 RUN conda update conda -n base && \
-    conda install mamba -n base -c defaults -c conda-forge
-#    conda config --set channel_priority strict
+    conda install mamba -n base -c defaults -c conda-forge && \
+    conda config --set channel_priority strict
 
 # to checkout other notebooks and to run pip install
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN chmod -R a+rwx /opt/conda
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
-    mamba create --name birdy xclim ravenpy --channel defaults --channel conda-forge && \
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
     mamba install --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,15 +37,8 @@ COPY environment.yml /environment.yml
 #
 # Conda was stuck at this step:
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
-#
-# Pin python=3.8 for vtk-cdat needed by vcs.  Otherwise, 3.9 would have been selected.
-#   package vcs-8.1-py_0 requires vtk-cdat >8.1, but none of the providers can be installed
-#   package vtk-cdat-8.2.0.8.2.1-py38hbc81915_0 requires python >=3.8,<3.9.0a0 *_cpython
-# Pin python=3.7 for libgdal (note libgdal was working with python 3.9 but blew up when we pin 3.8 for vcs)
-#   package gdal-3.1.4-py38h25844d8_1 requires libgdal 3.1.4 h50e41a3_1, but none of the providers can be installed
-# TODO remove python pin once a vtk-cdat for py39 exist, libgdal already worked for 3.9.
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.7 && \
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
     mamba env update --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,10 +51,6 @@ RUN mamba create --name birdy --channel conda-forge --channel defaults xclim rav
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
 
-# our notebooks are hardcoded to lookup for kernel named 'birdy'
-# this python is from the birdy env above
-RUN python -m ipykernel install --name birdy
-
 # install using same channel preferences as birdy original env to not downgrade
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
@@ -74,6 +70,10 @@ RUN jupyter serverextension enable voila --sys-prefix
 #    && jupyter labextension install jupyterlab-clipboard
 
 USER root
+
+# our notebooks are hardcoded to lookup for kernel named 'birdy'
+# this python is from the birdy env above
+RUN python -m ipykernel install --name birdy
 
 # This should be "master" but commit
 # https://github.com/jupyter/docker-stacks/commit/c772e98ac794173d6ed83a08ec249038b27ca3be

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,4 +86,4 @@ USER jenkins
 # Follow jupyter/base-notebook image so config in jupyterhub is simpler.
 # Unable to use the wrapper start-notebook.sh, it just does nothing so had to
 # hardcode what it should do.
-CMD ["jupyter", "lab", "${NOTEBOOK_ARGS}"]
+CMD ["jupyter", "lab"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,12 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
+# Pin python=3.8 for vtk-cdat needed by vcs.  Otherwise, 3.9 would have been selected.
+#   package vcs-8.1-py_0 requires vtk-cdat >8.1, but none of the providers can be installed
+#   package vtk-cdat-8.2.0.8.2.1-py38hbc81915_0 requires python >=3.8,<3.9.0a0 *_cpython
+# TODO remove python=3.8 pin once a vtk-cdat for py39 exist.
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.8
 
 COPY environment.yml /environment.yml
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,8 +19,6 @@ RUN groupadd --gid 1000 jenkins \
     && useradd --uid 1000 --gid jenkins --create-home jenkins && \
     chmod -R a+rwx /opt/conda
 
-COPY environment.yml /environment.yml
-
 # Use normal user to create the conda env so the user have full priviledge to
 # customize the env.
 USER jenkins
@@ -28,6 +26,8 @@ USER jenkins
 # Mamba creates temporary files in the PWD so have to switch to where jenkins
 # have write access.
 WORKDIR /home/jenkins
+
+COPY environment.yml /home/jenkins/environment.yml
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
@@ -46,7 +46,7 @@ WORKDIR /home/jenkins
 # Conda was stuck at this step:
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
 RUN mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
-    mamba env update --name birdy --file /environment.yml
+    mamba env update --name birdy --file /home/jenkins/environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,8 +37,13 @@ COPY environment.yml /environment.yml
 #
 # Conda was stuck at this step:
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
+#
+# Pin python=3.9 because python 3.10 cause this error:
+#   Encountered problems while solving:
+#     - package cartopy-0.20.1-py310h902574e_5 requires geos >=3.10.1,<3.10.2.0a0, but none of the providers can be installed
+#   This means there is no py310 build for geos package but https://anaconda.org/conda-forge/geos/files seems to be python indepdendent !
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.9 && \
     mamba env update --name birdy --file /environment.yml && \
     conda remove mamba -n base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,6 +67,11 @@ RUN jupyter lab build
 RUN jupyter serverextension enable voila --sys-prefix
 #    && jupyter labextension install jupyterlab-clipboard
 
+# This should be "master" but commit
+# https://github.com/jupyter/docker-stacks/commit/c772e98ac794173d6ed83a08ec249038b27ca3be
+# is breaking with us since we do not have user jovyan.
+ENV DOCKER_STACKS_COMMIT=709206ac8788475728cc9c992c25fb5f1501bc29
+
 # /notebook_dir for Pavics-landing notebooks to re-create Jupyter env layout:
 # /notebook_dir/writable-workspace, /notebook_dir/pavics-homepage.
 #
@@ -74,12 +79,12 @@ RUN jupyter serverextension enable voila --sys-prefix
 # hardcoded so users can copy the nb to writable-workspace/ dir and still be able
 # to run them seemlessly from the Jupyter env (without having to also copy
 # those *.geojson files with the notebooks).
-RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh --output-document /usr/local/bin/start.sh && \
-    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh --output-document /usr/local/bin/start-singleuser.sh && \
-    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh --output-document /usr/local/bin/start-notebook.sh && \
-    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/fix-permissions --output-document /usr/local/bin/fix-permissions && \
+RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_COMMIT/base-notebook/start.sh --output-document /usr/local/bin/start.sh && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_COMMIT/base-notebook/start-singleuser.sh --output-document /usr/local/bin/start-singleuser.sh && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_COMMIT/base-notebook/start-notebook.sh --output-document /usr/local/bin/start-notebook.sh && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_COMMIT/base-notebook/fix-permissions --output-document /usr/local/bin/fix-permissions && \
     mkdir /etc/jupyter && \
-    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/jupyter_notebook_config.py --output-document /etc/jupyter/jupyter_notebook_config.py && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_COMMIT/base-notebook/jupyter_notebook_config.py --output-document /etc/jupyter/jupyter_notebook_config.py && \
     chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions && \
     chmod a+r /etc/jupyter/jupyter_notebook_config.py && \
     mkdir /notebook_dir && chown jenkins /notebook_dir
@@ -88,7 +93,6 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-not
 # the jupyter/base-notebook image also do not default to root user so we do the same here
 USER jenkins
 
-# Follow jupyter/base-notebook image so config in jupyterhub is simpler.
-# Unable to use the wrapper start-notebook.sh, it just does nothing so had to
-# hardcode what it should do.
-CMD ["jupyter", "lab"]
+# follow jupyter/base-notebook image so config in jupyterhub is simpler
+# start notebook in conda environment to have working jupyter extensions
+CMD ["conda", "run", "-n", "birdy", "/usr/local/bin/start-notebook.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN chmod -R a+rwx /opt/conda
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
-    mamba create --name birdy xclim ravenpy && \
+    mamba create --name birdy xclim ravenpy --channel defaults --channel conda-forge && \
     mamba install --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
-RUN umask 0000 && conda create --name birdy --strict-channel-priority --verbose --verbose -f /environment.yml
+RUN umask 0000 && conda create --name birdy --strict-channel-priority --verbose --verbose --file /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,8 @@ COPY environment.yml /environment.yml
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
 RUN umask 0000 && \
     mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
-    mamba env update --name birdy --file /environment.yml
+    mamba env update --name birdy --file /environment.yml && \
+    conda remove mamba -n base
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,8 +42,9 @@ COPY environment.yml /environment.yml
 #   Encountered problems while solving:
 #     - package cartopy-0.20.1-py310h902574e_5 requires geos >=3.10.1,<3.10.2.0a0, but none of the providers can be installed
 #   This means there is no py310 build for geos package but https://anaconda.org/conda-forge/geos/files seems to be python indepdendent !
+# Pin python=3.8 because according to DavidH, xESMF has not been tested with 3.9 yet.
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.9 && \
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.8 && \
     mamba env update --name birdy --file /environment.yml && \
     conda remove mamba -n base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,12 @@ COPY environment.yml /environment.yml
 # Had to do this 2 stages install.  2 stages install was also taking forever
 # with conda so had to switch to mamba.
 #
+# One single 'conda env create -f /environment.yml' takes forever because we
+# removed all direct dependencies of xclim and ravenpy in /environment.yml for
+# dependencies pinning by xclim and ravenpy to take effect.  This results in
+# conda having a lot more packages to "solve" and it seems the solver
+# performance dropped exponentially with the number of packages to solve.
+#
 # Conda was stuck at this step:
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN umask 0000 && \
 
 # TODO: put back with previous layer, this one is to make sure we get latest xclim and ravenpy
 RUN umask 0000 && \
-    mamba update --name birdy --channel conda-forge --channel defaults xclim ravenpy
+    mamba install --name birdy --channel conda-forge --channel defaults "xclim>=0.32.1" "ravenpy>=0.7.5"
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
-RUN umask 0000 && conda create --name birdy --strict-channel-priority --verbose --verbose --file /environment.yml
+RUN umask 0000 && conda env create --verbose --verbose --file /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,12 +11,13 @@ RUN apt-get update && \
     firefox-esr x11-utils && \
     apt-get clean
 
-# needed for our specific jenkins
+# Create user jenkins for our Jenkins e2e notebooks test suite.
+# Change /opt/conda folder permissions for jupyter-conda extension.
 RUN groupadd --gid 1000 jenkins \
-    && useradd --uid 1000 --gid jenkins --create-home jenkins
+    && useradd --uid 1000 --gid jenkins --create-home jenkins && \
+    chmod -R a+rwx /opt/conda
 
-# Change these folders' permissions for jupyter-conda extension
-RUN chmod -R a+rwx /opt/conda
+COPY environment.yml /environment.yml
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
@@ -27,13 +28,7 @@ RUN chmod -R a+rwx /opt/conda
 #   package gdal-3.1.4-py38h25844d8_1 requires libgdal 3.1.4 h50e41a3_1, but none of the providers can be installed
 # TODO remove python pin once a vtk-cdat for py39 exist, libgdal already worked for 3.9.
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.7
-
-COPY environment.yml /environment.yml
-
-# TODO: put back with previous layer, temporary taken out to leverage build caching
-# This one downgraded xclim and ravenpy.
-RUN umask 0000 && \
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.7 && \
     mamba env update --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'
@@ -47,7 +42,7 @@ RUN python -m ipykernel install --name birdy
 # anything accidentally
 # this is for debug only, all dependencies should be specified in
 # environment.yml above
-# RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy nbdime
+# RUN mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 # Not needed with jupyterlab v3 anymore.
@@ -56,22 +51,21 @@ RUN python -m ipykernel install --name birdy
 RUN jupyter serverextension enable voila --sys-prefix
 #    && jupyter labextension install jupyterlab-clipboard
 
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh /usr/local/bin/
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/fix-permissions /usr/local/bin/
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/jupyter_notebook_config.py /etc/jupyter/
-RUN chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions; \
-    chmod a+r /etc/jupyter/jupyter_notebook_config.py
-
-# For Pavics-landing notebooks to re-create Jupyter env layout:
+# /notebook_dir for Pavics-landing notebooks to re-create Jupyter env layout:
 # /notebook_dir/writable-workspace, /notebook_dir/pavics-homepage.
 #
 # Path to the /notebook_dir/pavics-homepage/tutorial_data/*.geojson files are
 # hardcoded so users can copy the nb to writable-workspace/ dir and still be able
 # to run them seemlessly from the Jupyter env (without having to also copy
 # those *.geojson files with the notebooks).
-RUN mkdir /notebook_dir && chown jenkins /notebook_dir
+RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh --output-document /usr/local/bin/start.sh && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh --output-document /usr/local/bin/start-singleuser.sh && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh --output-document /usr/local/bin/start-notebook.sh && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/fix-permissions --output-document /usr/local/bin/fix-permissions && \
+    wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/jupyter_notebook_config.py --output-document /etc/jupyter/jupyter_notebook_config.py && \
+    chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions && \
+    chmod a+r /etc/jupyter/jupyter_notebook_config.py && \
+    mkdir /notebook_dir && chown jenkins /notebook_dir
 
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda3
 
 RUN conda update conda && \
-    conda install mamba -n base -c conda-forge && \
+    conda install mamba -n base -c defaults -c conda-forge && \
     conda config --set channel_priority strict
 
 # to checkout other notebooks and to run pip install
@@ -22,7 +22,7 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
-RUN umask 0000 && conda env create --verbose --verbose --file /environment.yml
+RUN umask 0000 && mamba env create --verbose --verbose --file /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM continuumio/miniconda3
 
-RUN conda update conda && \
-    conda install mamba -n base -c defaults -c conda-forge && \
-    conda config --set channel_priority strict
+RUN conda update conda -n base && \
+    conda install mamba -n base -c defaults -c conda-forge
+#    conda config --set channel_priority strict
 
 # to checkout other notebooks and to run pip install
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,9 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
-RUN umask 0000 && mamba env create --verbose --verbose --file /environment.yml
+RUN umask 0000 && \
+    mamba create --name birdy xclim ravenpy && \
+    mamba install --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,14 @@ RUN groupadd --gid 1000 jenkins \
 
 COPY environment.yml /environment.yml
 
+# Use normal user to create the conda env so the user have full priviledge to
+# customize the env.
+USER jenkins
+
+# Mamba creates temporary files in the PWD so have to switch to where jenkins
+# have write access.
+WORKDIR /home/jenkins
+
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 #
@@ -37,8 +45,7 @@ COPY environment.yml /environment.yml
 #
 # Conda was stuck at this step:
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
-RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
+RUN mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
     mamba env update --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'
@@ -65,6 +72,8 @@ RUN jupyter lab build
 
 RUN jupyter serverextension enable voila --sys-prefix
 #    && jupyter labextension install jupyterlab-clipboard
+
+USER root
 
 # This should be "master" but commit
 # https://github.com/jupyter/docker-stacks/commit/c772e98ac794173d6ed83a08ec249038b27ca3be

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
-RUN umask 0000 && conda env create --strict-channel-priority --verbose --verbose -f /environment.yml
+RUN umask 0000 && conda create --strict-channel-priority --verbose --verbose -f /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM continuumio/miniconda3
 
+# Use mamba for much improved performance over conda.
+# The 'channel_priority strict' did help conda but it was not enough.
 RUN conda update conda -n base && \
     conda install mamba -n base -c defaults -c conda-forge && \
     conda config --set channel_priority strict
@@ -21,6 +23,15 @@ COPY environment.yml /environment.yml
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
+#
+# Perform 2 stages install because one single 'conda env create -f
+# /environment.yml' was taking forever to complete, same with mamba.
+# Had to do this 2 stages install.  2 stages install was also taking forever
+# with conda so had to switch to mamba.
+#
+# Conda was stuck at this step:
+# DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
+#
 # Pin python=3.8 for vtk-cdat needed by vcs.  Otherwise, 3.9 would have been selected.
 #   package vcs-8.1-py_0 requires vtk-cdat >8.1, but none of the providers can be installed
 #   package vtk-cdat-8.2.0.8.2.1-py38hbc81915_0 requires python >=3.8,<3.9.0a0 *_cpython

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,10 @@ RUN chmod -R a+rwx /opt/conda
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy
+
+# TODO: put back with previous layer, temporary taken out to leverage build caching
+RUN umask 0000 && \
     mamba env update --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,8 +56,9 @@ RUN python -m ipykernel install --name birdy
 # RUN mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
-# Not needed with jupyterlab v3 anymore.
-#RUN jupyter lab build
+# Supposedly not needed with jupyterlab v3 anymore but see
+# https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998901247
+RUN jupyter lab build
 
 RUN jupyter serverextension enable voila --sys-prefix
 #    && jupyter labextension install jupyterlab-clipboard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,10 +46,8 @@ RUN python -m ipykernel install --name birdy
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 #RUN jupyter lab build
 
-# for ipywidgets to work with jupyter lab (notebooks works out of the box)
-RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager \
-    && jupyter serverextension enable voila --sys-prefix \
-    && jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-leaflet \
+RUN jupyter serverextension enable voila --sys-prefix \
+    && jupyter labextension install jupyter-leaflet \
     && jupyter labextension install jupyterlab-topbar-text \
                                     jupyterlab-theme-toggle
 #    && jupyter labextension install jupyterlab-clipboard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,6 +83,7 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-not
 # the jupyter/base-notebook image also do not default to root user so we do the same here
 USER jenkins
 
-# follow jupyter/base-notebook image so config in jupyterhub is simpler
-# start notebook in conda environment to have working jupyter extensions
-CMD ["conda", "run", "-n", "birdy", "/usr/local/bin/start-notebook.sh"]
+# Follow jupyter/base-notebook image so config in jupyterhub is simpler.
+# Unable to use the wrapper start-notebook.sh, it just does nothing so had to
+# hardcode what it should do.
+CMD ["jupyter", "lab", "${NOTEBOOK_ARGS}"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN chmod -R a+rwx /opt/conda
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults "xclim>=0.32.1" "ravenpy>=0.7.5"
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy
 
 COPY environment.yml /environment.yml
 
@@ -29,10 +29,6 @@ COPY environment.yml /environment.yml
 # This one downgraded xclim and ravenpy.
 RUN umask 0000 && \
     mamba env update --name birdy --file /environment.yml
-
-# TODO: put back with previous layer, this one is to make sure we get latest xclim and ravenpy
-RUN umask 0000 && \
-    mamba install --name birdy --channel conda-forge --channel defaults "xclim>=0.32.1" "ravenpy>=0.7.5"
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,6 @@ RUN python -m ipykernel install --name birdy
 #RUN jupyter lab build
 
 RUN jupyter serverextension enable voila --sys-prefix \
-    && jupyter labextension install jupyter-leaflet \
     && jupyter labextension install jupyterlab-topbar-text \
                                     jupyterlab-theme-toggle
 #    && jupyter labextension install jupyterlab-clipboard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,11 +44,10 @@ RUN python -m ipykernel install --name birdy
 # RUN conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy nbdime
 
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
+# Not needed with jupyterlab v3 anymore.
 #RUN jupyter lab build
 
-RUN jupyter serverextension enable voila --sys-prefix \
-    && jupyter labextension install jupyterlab-topbar-text \
-                                    jupyterlab-theme-toggle
+RUN jupyter serverextension enable voila --sys-prefix
 #    && jupyter labextension install jupyterlab-clipboard
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,6 +62,7 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-not
     wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh --output-document /usr/local/bin/start-singleuser.sh && \
     wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh --output-document /usr/local/bin/start-notebook.sh && \
     wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/fix-permissions --output-document /usr/local/bin/fix-permissions && \
+    mkdir /etc/jupyter && \
     wget https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/jupyter_notebook_config.py --output-document /etc/jupyter/jupyter_notebook_config.py && \
     chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions && \
     chmod a+r /etc/jupyter/jupyter_notebook_config.py && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
-RUN umask 0000 && conda env create --verbose --verbose -f /environment.yml
+RUN umask 0000 && conda env create --strict-channel-priority --verbose --verbose -f /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,10 @@ RUN python -m ipykernel install --name birdy
 # build jupyterlab extensions installed by conda, see `jupyter labextension list`
 # Supposedly not needed with jupyterlab v3 anymore but see
 # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998901247
+# TODO: remove 'jupyter lab build' step once all extensions move to prebuilt extensions,
+# see comment https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998917305
+# Currently jupyter-dash is holding back this step, see
+# https://github.com/plotly/jupyter-dash/issues/49
 RUN jupyter lab build
 
 RUN jupyter serverextension enable voila --sys-prefix

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,15 +19,7 @@ RUN groupadd --gid 1000 jenkins \
     && useradd --uid 1000 --gid jenkins --create-home jenkins && \
     chmod -R a+rwx /opt/conda
 
-# Use normal user to create the conda env so the user have full priviledge to
-# customize the env.
-USER jenkins
-
-# Mamba creates temporary files in the PWD so have to switch to where jenkins
-# have write access.
-WORKDIR /home/jenkins
-
-COPY environment.yml /home/jenkins/environment.yml
+COPY environment.yml /environment.yml
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
@@ -45,11 +37,16 @@ COPY environment.yml /home/jenkins/environment.yml
 #
 # Conda was stuck at this step:
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
-RUN mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
-    mamba env update --name birdy --file /home/jenkins/environment.yml
+RUN umask 0000 && \
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
+    mamba env update --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"
+
+# our notebooks are hardcoded to lookup for kernel named 'birdy'
+# this python is from the birdy env above
+RUN python -m ipykernel install --name birdy
 
 # install using same channel preferences as birdy original env to not downgrade
 # anything accidentally
@@ -68,12 +65,6 @@ RUN jupyter lab build
 
 RUN jupyter serverextension enable voila --sys-prefix
 #    && jupyter labextension install jupyterlab-clipboard
-
-USER root
-
-# our notebooks are hardcoded to lookup for kernel named 'birdy'
-# this python is from the birdy env above
-RUN python -m ipykernel install --name birdy
 
 # This should be "master" but commit
 # https://github.com/jupyter/docker-stacks/commit/c772e98ac794173d6ed83a08ec249038b27ca3be

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,9 +23,11 @@ RUN chmod -R a+rwx /opt/conda
 # Pin python=3.8 for vtk-cdat needed by vcs.  Otherwise, 3.9 would have been selected.
 #   package vcs-8.1-py_0 requires vtk-cdat >8.1, but none of the providers can be installed
 #   package vtk-cdat-8.2.0.8.2.1-py38hbc81915_0 requires python >=3.8,<3.9.0a0 *_cpython
-# TODO remove python=3.8 pin once a vtk-cdat for py39 exist.
+# Pin python=3.7 for libgdal (note libgdal was working with python 3.9 but blew up when we pin 3.8 for vcs)
+#   package gdal-3.1.4-py38h25844d8_1 requires libgdal 3.1.4 h50e41a3_1, but none of the providers can be installed
+# TODO remove python pin once a vtk-cdat for py39 exist, libgdal already worked for 3.9.
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.8
+    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy python=3.7
 
 COPY environment.yml /environment.yml
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN chmod -R a+rwx /opt/conda
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy
+    mamba create --name birdy --channel conda-forge --channel defaults "xclim>=0.32.1" "ravenpy>=0.7.5"
 
 COPY environment.yml /environment.yml
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod -R a+rwx /opt/conda
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
     mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
-    mamba env install --name birdy --file /environment.yml
+    mamba env update --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod -R a+rwx /opt/conda
 
 # create env "birdy"
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
-RUN umask 0000 && conda create --strict-channel-priority --verbose --verbose -f /environment.yml
+RUN umask 0000 && conda create --name birdy --strict-channel-priority --verbose --verbose -f /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update && \
     firefox-esr x11-utils && \
     apt-get clean
 
-COPY environment.yml /environment.yml
-
 # needed for our specific jenkins
 RUN groupadd --gid 1000 jenkins \
     && useradd --uid 1000 --gid jenkins --create-home jenkins
@@ -24,6 +22,8 @@ RUN chmod -R a+rwx /opt/conda
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
     mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy
+
+COPY environment.yml /environment.yml
 
 # TODO: put back with previous layer, temporary taken out to leverage build caching
 RUN umask 0000 && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,13 @@ RUN umask 0000 && \
 COPY environment.yml /environment.yml
 
 # TODO: put back with previous layer, temporary taken out to leverage build caching
+# This one downgraded xclim and ravenpy.
 RUN umask 0000 && \
     mamba env update --name birdy --file /environment.yml
+
+# TODO: put back with previous layer, this one is to make sure we get latest xclim and ravenpy
+RUN umask 0000 && \
+    mamba install --name birdy --channel conda-forge --channel defaults xclim ravenpy
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod -R a+rwx /opt/conda
 # use umask 0000 so that the files for the new environment are usable by user 'jenkins' for the jupyter-conda-extension
 RUN umask 0000 && \
     mamba create --name birdy --channel conda-forge --channel defaults xclim ravenpy && \
-    mamba install --name birdy --file /environment.yml
+    mamba env install --name birdy --file /environment.yml
 
 # alternate way to 'source activate birdy'
 ENV PATH="/opt/conda/envs/birdy/bin:$PATH"

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,15 +1,15 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:211123
+FROM pavics/workflow-tests:211221
 
 USER root
 
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
 RUN umask 0000 \
-    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy "rasterio<=1.2.6" "ravenpy>=0.7.5"
+    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy "shapely<=1.7.1" "bokeh<=2.3.3"
 #    && pip uninstall -y ravenpy \
-#    && conda install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
+#    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
 # RUN apt-get update && \
 #     DEBIAN_FRONTEND=noninteractive apt-get install -y unzip && \

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -13,8 +13,8 @@ dependencies:
 # xclim direct dependencies: https://github.com/conda-forge/xclim-feedstock/blob/master/recipe/meta.yaml
 # ravenpy direct dependencies: https://github.com/conda-forge/ravenpy-feedstock/blob/master/recipe/meta.yaml
 
-  - xclim >= 0.32.1
-  - ravenpy >= 0.7.5
+  - xclim # >= 0.32.1
+  - ravenpy # >= 0.7.5
 
   - matplotlib
     # - xarray  # from xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -80,11 +80,11 @@ dependencies:
   - zarr
   # https://github.com/dask/s3fs/
   - s3fs
-  - xclim == 0.31.0
+  - xclim
   # Pinning shapely for ravenpy.  Remove on next rebuild.
   # https://github.com/CSHS-CWRA/RavenPy/blob/f63e1e5b967c0d7c17e679c8f9d6d309a94096e6/environment.yml#L35
   # - shapely <=1.7.1  # from ravenpy
-  - ravenpy == 0.7.5
+  - ravenpy
   # https://github.com/roocs/clisops
   - clisops
   # Universal Regridder for Geospatial Data

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -145,7 +145,7 @@ dependencies:
   # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998901247
   # TODO: remove nodejs once all extensions move to prebuilt extensions, see comment
   # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998917305
-  - nodejs >= 17.1.0
+  - nodejs >= 16.0
   # utilities
   - curl
   - wget

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -9,12 +9,15 @@ channels:
 
 dependencies:
 
-# Do not put xclim and ravenpy direct dependencies here to let xclim and ravenpy
-# manage their own dependencies pinning.
-#
-# xclim direct dependencies: https://github.com/conda-forge/xclim-feedstock/blob/master/recipe/meta.yaml
-# ravenpy direct dependencies: https://github.com/conda-forge/ravenpy-feedstock/blob/master/recipe/meta.yaml
+  # Do not put xclim and ravenpy direct dependencies here to let xclim and ravenpy
+  # manage their own dependencies pinning.
+  #
+  # xclim direct dependencies: https://github.com/conda-forge/xclim-feedstock/blob/master/recipe/meta.yaml
+  # ravenpy direct dependencies: https://github.com/conda-forge/ravenpy-feedstock/blob/master/recipe/meta.yaml
 
+  # Pin latest xclim and ravenpy to avoid downgrading during the second install
+  # phase.  Mamba is quicker to solve dependencies than conda but it is less
+  # precise so accidental downgrade happends.
   - xclim >= 0.32.1
   - ravenpy >= 0.7.5
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -13,6 +13,9 @@ dependencies:
 # xclim direct dependencies: https://github.com/conda-forge/xclim-feedstock/blob/master/recipe/meta.yaml
 # ravenpy direct dependencies: https://github.com/conda-forge/ravenpy-feedstock/blob/master/recipe/meta.yaml
 
+  - xclim >= 0.32.1
+  - ravenpy >= 0.7.5
+
   - matplotlib
     # - xarray  # from xclim and ravenpy
     # - numpy  # from xclim and ravenpy
@@ -80,11 +83,9 @@ dependencies:
   - zarr
   # https://github.com/dask/s3fs/
   - s3fs
-  - xclim
   # Pinning shapely for ravenpy.  Remove on next rebuild.
   # https://github.com/CSHS-CWRA/RavenPy/blob/f63e1e5b967c0d7c17e679c8f9d6d309a94096e6/environment.yml#L35
   # - shapely <=1.7.1  # from ravenpy
-  - ravenpy
   # https://github.com/roocs/clisops
   - clisops
   # Universal Regridder for Geospatial Data

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -102,7 +102,11 @@ dependencies:
   # for esgf notebooks
   - esgf-compute-api
   - cdms2
-  - vcs
+  # Disable vcs because it was forcing python downgrade to below 3.9.
+  # See https://github.com/CDAT/vcs/issues/457
+  #   package vcs-8.1-py_0 requires vtk-cdat >8.1, but none of the providers can be installed
+  #   package vtk-cdat-8.2.0.8.2.1-py38hbc81915_0 requires python >=3.8,<3.9.0a0 *_cpython
+  #- vcs
   - mesalib
   # tests
   - pytest

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   # phase.  Mamba is quicker to solve dependencies than conda but it is less
   # precise so accidental downgrade happends.
   - xclim >= 0.32.1
-  - ravenpy >= 0.7.5
+  - ravenpy >= 0.7.6
 
   - matplotlib
     # - xarray  # from xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -101,8 +101,7 @@ dependencies:
   # for esgf notebooks
   - esgf-compute-api
   - cdms2
-  # vcs mamba install error: package vcs-8.1-py_0 requires vtk-cdat >8.1, but none of the providers can be installed
-  # - vcs
+  - vcs
   - mesalib
   # tests
   - pytest

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -113,6 +113,8 @@ dependencies:
   - notebook
   - jupyterlab
   - jupyterhub
+  # https://ipywidgets.readthedocs.io/en/latest/user_install.html
+  - ipywidgets
   # https://github.com/mamba-org/gator (was jupyter_conda)
   - mamba_gator
   # to diff .ipynb files

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -81,11 +81,11 @@ dependencies:
   - zarr
   # https://github.com/dask/s3fs/
   - s3fs
-  - xclim
+  - xclim == 0.31.0
   # Pinning shapely for ravenpy.  Remove on next rebuild.
   # https://github.com/CSHS-CWRA/RavenPy/blob/f63e1e5b967c0d7c17e679c8f9d6d309a94096e6/environment.yml#L35
   # - shapely <=1.7.1  # from ravenpy
-  - ravenpy
+  - ravenpy == 0.7.5
   # https://github.com/roocs/clisops
   - clisops
   # Universal Regridder for Geospatial Data

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -141,6 +141,9 @@ dependencies:
   # xeus-python: back-end kernel implementing the Jupyter Debug Protocol
   - xeus-python
   - jupyter-dash
+  # Force newer nodejs for 'jupyter lab build' issue
+  # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998901247
+  - nodejs >= 17.1.0
   # utilities
   - curl
   - wget

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -115,6 +115,8 @@ dependencies:
   - jupyterhub
   # https://ipywidgets.readthedocs.io/en/latest/user_install.html
   - ipywidgets
+  # https://github.com/jupyter-widgets/ipyleaflet
+  - ipyleaflet
   # https://github.com/mamba-org/gator (was jupyter_conda)
   - mamba_gator
   # to diff .ipynb files

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -3,6 +3,7 @@ name: birdy
 channels:
   - conda-forge
   - cdat
+  - uvcdat  # for vtk-cdat needed by vcs
   - bokeh
   - plotly  # for jupyter-dash
 dependencies:

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -5,7 +5,6 @@ channels:
   - cdat
   - bokeh
   - plotly  # for jupyter-dash
-  - defaults
 dependencies:
 
 # Do not put xclim and ravenpy direct dependencies here to let xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -21,11 +21,6 @@ dependencies:
   - xclim >= 0.32.1
   - ravenpy >= 0.7.7
 
-  # Avoid openssl downgrade during second install phase by mamba.
-  # - openssl 3.0.0 h7f98852_2 installed
-  # + openssl 1.1.1l h7f98852_0 conda-forge/linux-64 2 MB
-  - openssl >= 3.0
-
   - matplotlib
     # - xarray  # from xclim and ravenpy
     # - numpy  # from xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -34,9 +34,7 @@ dependencies:
   - pydap
   - cartopy
   - descartes
-  # Pin rasterio for ravenpy, remove on next build.
-  # See https://github.com/CSHS-CWRA/RavenPy/commit/eae66e9afc30e2381e9119644a0695d1d248c739
-    # - rasterio <= 1.2.6  # from ravenpy
+    # - rasterio  # from ravenpy
     # - gdal  # for osgeo, from ravenpy
     # - geopandas  # from ravenpy
     # - pandas  # from xclim and ravenpy
@@ -88,9 +86,7 @@ dependencies:
   - zarr
   # https://github.com/dask/s3fs/
   - s3fs
-  # Pinning shapely for ravenpy.  Remove on next rebuild.
-  # https://github.com/CSHS-CWRA/RavenPy/blob/f63e1e5b967c0d7c17e679c8f9d6d309a94096e6/environment.yml#L35
-  # - shapely <=1.7.1  # from ravenpy
+    # - shapely  # from ravenpy
   # https://github.com/roocs/clisops
   - clisops
   # Universal Regridder for Geospatial Data

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -87,6 +87,27 @@ dependencies:
   # https://github.com/dask/s3fs/
   - s3fs
     # - shapely  # from ravenpy
+  # PIN shapely due to notebook failure
+  # PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb:
+  #   /opt/conda/envs/birdy/lib/python3.7/site-packages/shapely/geometry/base.py in array_interface_base(self)
+  #       324             "removed in Shapely 2.0.",
+  #       325             ShapelyDeprecationWarning, stacklevel=2)
+  #   --> 326         return self._array_interface_base()
+  #       327 
+  #       328     @property
+  #
+  #   TypeError: 'dict' object is not callable
+  #
+  # climex.ipynb:
+  #   /opt/conda/envs/birdy/lib/python3.7/site-packages/cartopy/crs.py:825: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.
+  #     if len(multi_line_string) > 1:
+  #   /opt/conda/envs/birdy/lib/python3.7/site-packages/cartopy/crs.py:877: ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.
+  #     for line in multi_line_string:
+  #   /opt/conda/envs/birdy/lib/python3.7/site-packages/cartopy/crs.py:944: ShapelyDeprecationWarning: __len__ for multi-part geometries is deprecated and will be removed in Shapely 2.0. Check the length of the `geoms` property instead to get the  number of parts of a multi-part geometry.
+  #     if len(p_mline) > 0:
+  #   /opt/conda/envs/birdy/lib/python3.7/site-packages/cartopy/io/__init__.py:241: DownloadWarning: Downloading: https://naturalearth.s3.amazonaws.com/10m_physical/ne_10m_coastline.zip
+  #     warnings.warn(f'Downloading: {url}', DownloadWarning)
+  - shapely <= 1.7.1
   # https://github.com/roocs/clisops
   - clisops >= 0.8.0
   # Universal Regridder for Geospatial Data

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -3,7 +3,6 @@ name: birdy
 channels:
   - conda-forge
   - cdat
-  - uvcdat  # for vtk-cdat needed by vcs
   - bokeh
   - plotly  # for jupyter-dash
 dependencies:

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -100,7 +100,8 @@ dependencies:
   # for esgf notebooks
   - esgf-compute-api
   - cdms2
-  - vcs
+  # vcs mamba install error: package vcs-8.1-py_0 requires vtk-cdat >8.1, but none of the providers can be installed
+  # - vcs
   - mesalib
   # tests
   - pytest

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -5,6 +5,8 @@ channels:
   - cdat
   - bokeh
   - plotly  # for jupyter-dash
+  - defaults
+
 dependencies:
 
 # Do not put xclim and ravenpy direct dependencies here to let xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -21,6 +21,11 @@ dependencies:
   - xclim >= 0.32.1
   - ravenpy >= 0.7.7
 
+  # Avoid openssl downgrade during second install phase by mamba.
+  # - openssl 3.0.0 h7f98852_2 installed
+  # + openssl 1.1.1l h7f98852_0 conda-forge/linux-64 2 MB
+  - openssl >= 3.0
+
   - matplotlib
     # - xarray  # from xclim and ravenpy
     # - numpy  # from xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   # phase.  Mamba is quicker to solve dependencies than conda but it is less
   # precise so accidental downgrade happends.
   - xclim >= 0.32.1
-  - ravenpy >= 0.7.7
+  - ravenpy >= 0.7.8
 
   - matplotlib
     # - xarray  # from xclim and ravenpy
@@ -88,13 +88,11 @@ dependencies:
   - s3fs
     # - shapely  # from ravenpy
   # https://github.com/roocs/clisops
-  - clisops
+  - clisops >= 0.8.0
   # Universal Regridder for Geospatial Data
   # https://github.com/pangeo-data/xESMF
-  # Pin xesmf because latest xesmf-0.6.2 is not compatible with latest clisops-0.7.0.
-  # xesmf-0.6.1 is buggy.
-  # Unpin when new compatible clisops is released.
-  - xesmf <= 0.6.0
+  # xesmf-0.6.2 requires clisops>=0.8.0
+  - xesmf >= 0.6.2
   # https://anaconda.org/anaconda/memory_profiler
   # Monitor memory consumption of a process as well as line-by-line analysis
   # of memory consumption for Python programs.

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -143,6 +143,8 @@ dependencies:
   - jupyter-dash
   # Force newer nodejs for 'jupyter lab build' issue
   # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998901247
+  # TODO: remove nodejs once all extensions move to prebuilt extensions, see comment
+  # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998917305
   - nodejs >= 17.1.0
   # utilities
   - curl

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   # following the CF Conventions.
   - cfgrib
   - pydap
-  - cartopy
+  - cartopy >= 0.20.1
   - descartes
     # - rasterio  # from ravenpy
     # - gdal  # for osgeo, from ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -13,8 +13,8 @@ dependencies:
 # xclim direct dependencies: https://github.com/conda-forge/xclim-feedstock/blob/master/recipe/meta.yaml
 # ravenpy direct dependencies: https://github.com/conda-forge/ravenpy-feedstock/blob/master/recipe/meta.yaml
 
-  - xclim # >= 0.32.1
-  - ravenpy # >= 0.7.5
+  - xclim >= 0.32.1
+  - ravenpy >= 0.7.5
 
   - matplotlib
     # - xarray  # from xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   # phase.  Mamba is quicker to solve dependencies than conda but it is less
   # precise so accidental downgrade happends.
   - xclim >= 0.32.1
-  - ravenpy >= 0.7.6
+  - ravenpy >= 0.7.7
 
   - matplotlib
     # - xarray  # from xclim and ravenpy

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:211221"
+    DOCKER_IMAGE="pavics/workflow-tests:220116"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220116"
+    DOCKER_IMAGE="pavics/workflow-tests:220116.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:211123-update211216"
+    DOCKER_IMAGE="pavics/workflow-tests:211221"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220116.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220121"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:211221"
+    DOCKER_IMAGE="pavics/workflow-tests:220116"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220116.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220121"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:211123-update211216"
+    DOCKER_IMAGE="pavics/workflow-tests:211221"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220116"
+    DOCKER_IMAGE="pavics/workflow-tests:220116.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
# Overview

Previously, when xclim and ravenpy were pinning their own dependencies, the pins were ignored and we had to manually repeat the same pins again.  See comment https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/94#issuecomment-996841873.

This PR allows xclim and ravenpy to manage their own dependencies pinning transparently during this Jupyter env rebuild.

Also fixed a long standing build performance along the way.  Build time went from 50 mins to 25 mins and builds on DockerHub works again.

Deployed as "beta" image on https://pavics.ouranos.ca/jupyter for testing.


## Changes

- Switched to using mamba instead of conda since mamba dependency solver is faster.  Mamba solver being faster at the expense of less precision so had to pin latest xclim and ravenpy to avoid random downgrade in the 2nd build phase.

  Both solvers performance seem to drop exponentially when less packages are specified directly, leading to more work for the solver to discover them.  Less packages specified directly because we removed all direct dependencies of xclim and ravenpy from the `environment.yml` file.

- Switched to using 2 stages conda env build as another performance work-around.  One single `conda env create -f /environment.yml` was taking many days !  mamba was not much better in one single stage build.

  With 2 stages build, a build using conda solver takes 5 hours while mamba solver takes 25 minutes !

- Reduced the number of "build layers" by merging several of them, for another small build performance gain.

- `jupyterlab-topbar-text` and `jupyterlab-theme-toggle` jupyterlab extension was removed due to javascript build problem.  The topbar text was pretty useless.  Hopefully the theme toogle is not so widely used.

- Had to hardcode the commit of the https://github.com/jupyter/docker-stacks repo where we get the startup script from because the latest version of those scripts are breaking us.  This will have to be solve later.

- Removed  `vcs` library from `cdat` channel in order to move to python 3.9.  Otherwise we are stuck on 3.7 and xarray will drop 3.7 soon.   I've opened an issue on CDAT side  https://github.com/CDAT/vcs/issues/457.  `vcs` library was needed to run ESGF notebooks at https://github.com/ESGF/esgf-compute-api/tree/devel/examples


## Related Issue / Discussion

- Related issues https://github.com/jupyterlab/jupyterlab/issues/11726

- Notebook fix needed https://github.com/Ouranosinc/PAVICS-landing/pull/42

- Matching PR to deploy this new Jupyter env to PAVICS https://github.com/bird-house/birdhouse-deploy/pull/234


## Additional Information

- Screenshot of UI change showing `jupyterlab-topbar-text` and `jupyterlab-theme-toggle` jupyterlab extension removed:
![Screenshot from 2021-12-21 17-10-25](https://user-images.githubusercontent.com/11966697/147004835-ce14fc15-d04f-4956-b416-b45927b5cb4d.png)

- Relevant changes:
```diff
<   - xclim=0.31.0=pyhd8ed1ab_0
>   - xclim=0.32.1=pyhd8ed1ab_0

<   - ravenpy=0.7.5=pyhff6ddc9_0
>   - ravenpy=0.7.8=pyh8a188c0_0

<   - python=3.7.12=hb7a2778_100_cpython
>   - python=3.8.12=hb7a2778_2_cpython

# removed
<   - vcs=8.2.1=pyh9f0ad1d_0

<   - numpy=1.21.4=py37h31617e3_0
>   - numpy=1.21.5=py38h87f13fb_0

<   - xarray=0.20.1=pyhd8ed1ab_0
>   - xarray=0.20.2=pyhd8ed1ab_0

<   - rioxarray=0.8.0=pyhd8ed1ab_0
>   - rioxarray=0.9.1=pyhd8ed1ab_0

<   - cf_xarray=0.6.1=pyh6c4a22f_0
>   - cf_xarray=0.6.3=pyhd8ed1ab_0

<   - gdal=3.3.2=py37hd5a0ba4_2
>   - gdal=3.3.3=py38hcf2042a_0

<   - rasterio=1.2.6=py37hc20819c_2
>   - rasterio=1.2.10=py38hfd64e68_0

<   - climpred=2.1.6=pyhd8ed1ab_1
>   - climpred=2.2.0=pyhd8ed1ab_0

<   - clisops=0.7.0=pyh6c4a22f_0
>   - clisops=0.8.0=pyh6c4a22f_0

<   - xesmf=0.6.0=pyhd8ed1ab_0
>   - xesmf=0.6.2=pyhd8ed1ab_0

<   - birdy=v0.8.0=pyh6c4a22f_1
>   - birdy=0.8.1=pyh6c4a22f_1

<   - cartopy=0.20.0=py37hbe109c4_0
>   - cartopy=0.20.1=py38hf9a4893_1

<   - dask=2021.11.2=pyhd8ed1ab_0
>   - dask=2022.1.0=pyhd8ed1ab_0

<   - numba=0.53.1=py37hb11d6e1_1
>   - numba=0.55.0=py38h4bf6c61_0

<   - pandas=1.3.4=py37he8f5f7f_1
>   - pandas=1.3.5=py38h43a58ef_0

```

- Full diff of `conda env export`: 

[211123-update211216-211221-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7758757/211123-update211216-211221-conda-env-export.diff.txt)

[211221-220116.1-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7909174/211221-220116.1-conda-env-export.diff.txt)

[211123-update211216-220116.1-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7909172/211123-update211216-220116.1-conda-env-export.diff.txt)

[220116.1-220121-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7922627/220116.1-220121-conda-env-export.diff.txt)

[211123-update211216-220121-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7922628/211123-update211216-220121-conda-env-export.diff.txt)


- Full new `conda env export`: 

[211221-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7758759/211221-conda-env-export.yml.txt)

[220116.1-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7909175/220116.1-conda-env-export.yml.txt)

[220121-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/7922629/220121-conda-env-export.yml.txt)

