### PR TITLE
Update xESMF

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -86,7 +86,7 @@ dependencies:
   # Pin xesmf because latest xesmf-0.6.2 is not compatible with latest clisops-0.7.0.
   # xesmf-0.6.1 is buggy.
   # Unpin when new compatible clisops is released.
-  - xesmf <= 0.6.0
+  - xesmf >= 0.6.2
   # https://anaconda.org/anaconda/memory_profiler
   # Monitor memory consumption of a process as well as line-by-line analysis
   # of memory consumption for Python programs.


### PR DESCRIPTION
# Overview

This should also unlock clisops so it's at 0.8.0. 

cf-xarray is not mentioned explicitly in the env, but hopefull the latest version (0.6.3) will be picked up. 


