### PR TITLE
New Jupyter env build with new xlrd, pre-commit, pin dask, distributed, cf_xarray, latest of everything else

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220401.1"
+            image "pavics/workflow-tests:220401"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220121"
+            image "pavics/workflow-tests:220318"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220318.1"
+            image "pavics/workflow-tests:220401"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220401"
+            image "pavics/workflow-tests:220401.1"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220318"
+            image "pavics/workflow-tests:220318.1"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220401.1
+FROM pavics/workflow-tests:220401
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220318
+FROM pavics/workflow-tests:220318.1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220401
+FROM pavics/workflow-tests:220401.1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220121
+FROM pavics/workflow-tests:220318
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220318.1
+FROM pavics/workflow-tests:220401
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,7 +93,8 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_
     wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_COMMIT/base-notebook/jupyter_notebook_config.py --output-document /etc/jupyter/jupyter_notebook_config.py && \
     chmod a+rx /usr/local/bin/start.sh /usr/local/bin/start-singleuser.sh /usr/local/bin/start-notebook.sh /usr/local/bin/fix-permissions && \
     chmod a+r /etc/jupyter/jupyter_notebook_config.py && \
-    mkdir /notebook_dir && chown jenkins /notebook_dir
+    mkdir /notebook_dir && chown jenkins /notebook_dir && \
+    chmod a+rwX -R /opt/conda/envs/birdy/fonts
 
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,13 +1,17 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:211221
+FROM pavics/workflow-tests:220201
 
 USER root
 
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
+# Pin dask and distributed for slow PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb.
+# Pin cf_xarray for slow WPS_example.ipynb.
 RUN umask 0000 \
-    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy "shapely<=1.7.1" "bokeh<=2.3.3"
+    && conda install -c conda-forge mamba -n base \
+    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy "dask<=2022.1.0" "distributed<=2022.1.0" "cf_xarray<=0.6.3" \
+    && conda remove mamba -n base
 #    && pip uninstall -y ravenpy \
 #    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -23,6 +23,7 @@ dependencies:
 
   # Pin dask and distributed for slow PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb.
   # Same as in commit https://github.com/bird-house/finch/pull/226/commits/7bf4a7e1bcb12bc88d15bdcbbd484e81106be67c
+  # See issue https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/100
   - dask <= 2022.1.0
   - distributed <= 2022.1.0
 
@@ -96,6 +97,7 @@ dependencies:
   - s3fs
     # - shapely  # from ravenpy
   # PIN shapely due to notebook failure
+  # See issue https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/99
   # PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb:
   #   /opt/conda/envs/birdy/lib/python3.7/site-packages/shapely/geometry/base.py in array_interface_base(self)
   #       324             "removed in Shapely 2.0.",

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -181,6 +181,8 @@ dependencies:
   - scp
   - selenium
   - geckodriver
+  - xlrd
+  - pre-commit
   # for pip packages
   - pip
   - pip:

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -21,14 +21,6 @@ dependencies:
   - xclim >= 0.32.1
   - ravenpy >= 0.7.8
 
-  # Pin dask and distributed for slow PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb.
-  # Same as in commit https://github.com/bird-house/finch/pull/226/commits/7bf4a7e1bcb12bc88d15bdcbbd484e81106be67c
-  - dask <= 2022.1.0
-  - distributed <= 2022.1.0
-
-  # Pin cf_xarray for slow WPS_example.ipynb.
-  - cf_xarray<=0.6.3
-
   - matplotlib
     # - xarray  # from xclim and ravenpy
     # - numpy  # from xclim and ravenpy

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -21,6 +21,14 @@ dependencies:
   - xclim >= 0.32.1
   - ravenpy >= 0.7.8
 
+  # Pin dask and distributed for slow PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb.
+  # Same as in commit https://github.com/bird-house/finch/pull/226/commits/7bf4a7e1bcb12bc88d15bdcbbd484e81106be67c
+  - dask <= 2022.1.0
+  - distributed <= 2022.1.0
+
+  # Pin cf_xarray for slow WPS_example.ipynb.
+  - cf_xarray<=0.6.3
+
   - matplotlib
     # - xarray  # from xclim and ravenpy
     # - numpy  # from xclim and ravenpy

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220318"
+    DOCKER_IMAGE="pavics/workflow-tests:220318.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220121"
+    DOCKER_IMAGE="pavics/workflow-tests:220318"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220401.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220401"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220401"
+    DOCKER_IMAGE="pavics/workflow-tests:220401.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220318.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220401"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220121"
+    DOCKER_IMAGE="pavics/workflow-tests:220318"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220401.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220401"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220318.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220401"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220318"
+    DOCKER_IMAGE="pavics/workflow-tests:220318.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220401"
+    DOCKER_IMAGE="pavics/workflow-tests:220401.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
## Relevant Changes

```diff
>   - pre-commit=2.17.0=py38h578d9bd_0
>   - xlrd=2.0.1=pyhd8ed1ab_3

<   - xclim=0.32.1=pyhd8ed1ab_0
>   - xclim=0.34.0=pyhd8ed1ab_0

<   - cfgrib=0.9.9.1=pyhd8ed1ab_1
>   - cfgrib=0.9.10.1=pyhd8ed1ab_0

<   - cftime=1.5.1.1=py38h6c62de6_1
>   - cftime=1.6.0=py38h3ec907f_0

<   - intake-xarray=0.5.0=pyhd8ed1ab_0
>   - intake-xarray=0.6.0=pyhd8ed1ab_0

<   - pandas=1.3.5=py38h43a58ef_0
>   - pandas=1.4.1=py38h43a58ef_0

<   - regionmask=0.8.0=pyhd8ed1ab_1
>   - regionmask=0.9.0=pyhd8ed1ab_0

<   - rioxarray=0.9.1=pyhd8ed1ab_0
>   - rioxarray=0.10.3=pyhd8ed1ab_0

<   - xarray=0.20.2=pyhd8ed1ab_0
>   - xarray=2022.3.0=pyhd8ed1ab_0

<   - zarr=2.10.3=pyhd8ed1ab_0
>   - zarr=2.11.1=pyhd8ed1ab_0
```

## New Packages Pins
`dask` and `distributed` was causing `PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb` to run excessively slow. 

`cf_xarray` caused `WPS_example.ipynb` to be slow.

See https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/100 for more info why these had to be pinned.

## Related Issue / Discussion

- Fixes https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/97
- https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/99
- https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/100
- PR to deploy this new Jupyter env to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/240

## Test  Results

- Deployed as "beta" image in production for bokeh visualization performance regression testing.

- Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.

- Jenkins build, only known intermittent error: subset-user-input.ipynb: RemoteDisconnected, slow WPS_example.ipynb: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/preview-docker-build/37/console, logs: [job-PAVICS-e2e-workflow-tests-preview-docker-build-37-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8401086/job-PAVICS-e2e-workflow-tests-preview-docker-build-37-consoleText.txt)
- Jenkins build 2, only known intermittent error: subset-user-input.ipynb: RemoteDisconnected, opendap.ipynb runtime crashed: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build/7/console, logs: [job-PAVICS-e2e-workflow-tests-new-docker-build-7-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8401197/job-PAVICS-e2e-workflow-tests-new-docker-build-7-consoleText.txt)
- Jenkins build 3, only known intermittent error: stress-test.ipynb "ValueError: max() arg is an empty sequence": http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build/8/console, logs: [job-PAVICS-e2e-workflow-tests-new-docker-build-8-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8410742/job-PAVICS-e2e-workflow-tests-new-docker-build-8-consoleText.txt)
- Jenkins build 4, only known intermittent error: WMS_example.ipynb: SyntaxError: not a PNG file, stress-tests.ipynb: ValueError: max() arg is an empty sequence, , slow WPS_example.ipynb: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/new-docker-build/12/console, logs: [job-PAVICS-e2e-workflow-tests-new-docker-build-12-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8411737/job-PAVICS-e2e-workflow-tests-new-docker-build-12-consoleText.txt)

## Additional Information

- Full `conda env export` diff:
[220121-220401-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8401067/220121-220401-conda-env-export.diff.txt)

- Full new `conda env export`: 
[220401-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8401069/220401-conda-env-export.yml.txt)


