### PR TITLE
test framework: allow testing using all test data from system under test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ Requires 'weaver' component to be active on the target 'PAVICS_HOST' server
         string(name: 'PYTEST_EXTRA_OPTS', defaultValue: '',
                description: 'Extra options to pass to pytest, ex: --nbval-lax', trim: true)
         string(name: 'EXTRA_TEST_ENV_VAR', defaultValue: '',
-               description: 'Extra environment variables for the various tests, ex: "TEST_RUNS=50 TEST_WPS_BIRDS=finch,raven,flyingpigeon"', trim: true)
+               description: 'Extra environment variables for the various tests, ex: "TEST_RUNS=50 TEST_WPS_BIRDS=finch,raven,flyingpigeon TEST_NO_USE_PROD_DATA=1"', trim: true)
         booleanParam(name: 'TEST_LOCAL_NOTEBOOKS', defaultValue: true,
                      description: 'Check the box to test notebooks in this repo (./notebooks/*.ipynb).')
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,

--- a/runtest
+++ b/runtest
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+DEFAULT_PRODUCTION_HOST="pavics.ouranos.ca"
+
 NOTEBOOKS="$1"
 if [ -z "$NOTEBOOKS" ]; then
     NOTEBOOKS="notebooks/*.ipynb"
@@ -16,12 +18,19 @@ fi
 
 if [ ! -z "$PAVICS_HOST" ]; then
     echo "Will run notebooks against $PAVICS_HOST"
-    # * .ncml links will always comes from the production server, not the server
-    # under test since we do not perform regex replace for .ncml links.
-    #
-    # * Any lines marked with TEST_USE_PROD_DATA will also use data from prod
-    # and avoid having to replicate data to test servers.
-    sed -i "/\(\.ncml\|TEST_USE_PROD_DATA\)/!s/pavics.ouranos.ca/$PAVICS_HOST/g" $NOTEBOOKS
+
+    if [ -z "$TEST_NO_USE_PROD_DATA" ]; then
+        # * .ncml links will always comes from the production server, not the server
+        # under test since we do not perform regex replace for .ncml links.
+        #
+        # * Any lines marked with TEST_USE_PROD_DATA will also use data from prod
+        # and avoid having to replicate data to test servers.
+        sed -i "/\(\.ncml\|TEST_USE_PROD_DATA\)/!s/$DEFAULT_PRODUCTION_HOST/$PAVICS_HOST/g" $NOTEBOOKS
+    else
+        # Change everything to $PAVICS_HOST (system under test).
+        sed -i "s/$DEFAULT_PRODUCTION_HOST/$PAVICS_HOST/g" $NOTEBOOKS
+    fi
+
     git diff  # not working for notebooks from other repos
 fi
 


### PR DESCRIPTION
Set `TEST_NO_USE_PROD_DATA` to use all test data from system under test.

Useful to test future production server that will have all the huge datas.

Fixes https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/103.

Relate to https://github.com/bird-house/finch/pull/232 and https://github.com/Ouranosinc/pavics-sdi/pull/254.