### PR TITLE
docker: new build for new XClim and to get Dask dashboard and Panel server app to work

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220407"
+            image "pavics/workflow-tests:220407.1"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220401"
+            image "pavics/workflow-tests:220407"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220412"
+            image "pavics/workflow-tests:220414"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:220407.1"
+            image "pavics/workflow-tests:220412"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220412
+FROM pavics/workflow-tests:220414
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /notebooks
 
 RUN ./downloadrepos; DEPLOY_PAVICS_LANDING_NB=1 ./reorg-notebooks; rm -rfv downloadrepos default_build_params reorg-notebooks; chown -R jenkins:jenkins .
 
-RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
+RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/0c7e0ab4af7b51aa5320b873b7f1bf641fc03e27/test-panel.ipynb -O TEST-panel.ipynb; chown jenkins:jenkins TEST-panel.ipynb
+
+# RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 
 USER jenkins

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -25,3 +25,5 @@ RUN chmod a+rwX -R /opt/conda/pkgs/cache/
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 
 USER jenkins
+
+RUN conda install -c pyviz/label/dev jupyter-panel-proxy

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -18,7 +18,8 @@ COPY binder/test-notebooks /notebooks
 
 RUN mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb
 
-RUN chown jenkins:jenkins -R .
+# test whether Panel launcher requires writable perm at current launch dir
+# RUN chown jenkins:jenkins -R .
 
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -20,6 +20,8 @@ RUN mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipy
 
 RUN chown jenkins:jenkins -R .
 
+RUN chmod a+rwX -R /opt/conda/pkgs/cache/
+
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 
 USER jenkins

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -18,8 +18,7 @@ COPY binder/test-notebooks /notebooks
 
 RUN mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb
 
-# test whether Panel launcher requires writable perm at current launch dir
-# RUN chown jenkins:jenkins -R .
+RUN chown jenkins:jenkins -R .
 
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220401
+FROM pavics/workflow-tests:220407
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /notebooks
 
 ENV BOKEH_ALLOW_WS_ORIGIN "*"
 
-RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-binder.ipynb -O TEST-panel-binder.ipynb; wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-servable.ipynb -O TEST-panel-servable.ipynb; chown jenkins:jenkins *.ipynb
+RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-binder.ipynb -O TEST-panel-binder.ipynb; wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-servable.ipynb -O TEST-panel-servable.ipynb; chown jenkins:jenkins -R .
 
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /notebooks
 
 ENV BOKEH_ALLOW_WS_ORIGIN "*"
 
-RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-binder.ipynb -O TEST-panel-binder.ipynb; wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-servable.ipynb -O TEST-panel-servable.ipynb; chown jenkins:jenkins -R .
+RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-binder.ipynb -O TEST-panel-binder.ipynb; wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-servable.ipynb -O TEST-panel-servable.ipynb; mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb; chown jenkins:jenkins -R .
 
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -12,18 +12,12 @@ WORKDIR /notebooks
 
 #RUN ./downloadrepos; DEPLOY_PAVICS_LANDING_NB=1 ./reorg-notebooks; rm -rfv downloadrepos default_build_params reorg-notebooks; chown -R jenkins:jenkins .
 
-ENV BOKEH_ALLOW_WS_ORIGIN "*"
-
 COPY binder/test-notebooks /notebooks
 
 RUN mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb
 
 RUN chown jenkins:jenkins -R .
 
-RUN chmod a+rwX -R /opt/conda/pkgs/cache/
-
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 
 USER jenkins
-
-RUN conda install -c pyviz/label/dev jupyter-panel-proxy

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,17 +2,19 @@ FROM pavics/workflow-tests:220414
 
 USER root
 
-COPY notebooks /notebooks
+#COPY notebooks /notebooks
 
-COPY default_build_params /notebooks
-COPY downloadrepos /notebooks
-COPY binder/reorg-notebooks /notebooks
+#COPY default_build_params /notebooks
+#COPY downloadrepos /notebooks
+#COPY binder/reorg-notebooks /notebooks
 
 WORKDIR /notebooks
 
-RUN ./downloadrepos; DEPLOY_PAVICS_LANDING_NB=1 ./reorg-notebooks; rm -rfv downloadrepos default_build_params reorg-notebooks; chown -R jenkins:jenkins .
+#RUN ./downloadrepos; DEPLOY_PAVICS_LANDING_NB=1 ./reorg-notebooks; rm -rfv downloadrepos default_build_params reorg-notebooks; chown -R jenkins:jenkins .
 
-RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/0c7e0ab4af7b51aa5320b873b7f1bf641fc03e27/test-panel.ipynb -O TEST-panel.ipynb; chown jenkins:jenkins TEST-panel.ipynb
+ENV BOKEH_ALLOW_WS_ORIGIN "*"
+
+RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-binder.ipynb -O TEST-panel-binder.ipynb; wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-servable.ipynb -O TEST-panel-servable.ipynb; chown jenkins:jenkins *.ipynb
 
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -2,21 +2,21 @@ FROM pavics/workflow-tests:220502
 
 USER root
 
-#COPY notebooks /notebooks
+COPY notebooks /notebooks
 
-#COPY default_build_params /notebooks
-#COPY downloadrepos /notebooks
-#COPY binder/reorg-notebooks /notebooks
+COPY default_build_params /notebooks
+COPY downloadrepos /notebooks
+COPY binder/reorg-notebooks /notebooks
 
 WORKDIR /notebooks
 
-#RUN ./downloadrepos; DEPLOY_PAVICS_LANDING_NB=1 ./reorg-notebooks; rm -rfv downloadrepos default_build_params reorg-notebooks; chown -R jenkins:jenkins .
+RUN ./downloadrepos; DEPLOY_PAVICS_LANDING_NB=1 ./reorg-notebooks; rm -rfv downloadrepos default_build_params reorg-notebooks; chown -R jenkins:jenkins .
 
-COPY binder/test-notebooks /notebooks
+#COPY binder/test-notebooks /notebooks
 
-RUN mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb
+#RUN mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb
 
-RUN chown jenkins:jenkins -R .
+#RUN chown jenkins:jenkins -R .
 
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220407
+FROM pavics/workflow-tests:220407.1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -14,7 +14,11 @@ WORKDIR /notebooks
 
 ENV BOKEH_ALLOW_WS_ORIGIN "*"
 
-RUN wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-binder.ipynb -O TEST-panel-binder.ipynb; wget https://gist.githubusercontent.com/tlvu/f8a91585bac38af23c4f4490f94fc513/raw/30894efd1c0cd6b759b2a911e6fe50f16deae14d/TEST-panel-servable.ipynb -O TEST-panel-servable.ipynb; mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb; chown jenkins:jenkins -R .
+COPY binder/test-notebooks /notebooks
+
+RUN mkdir -p subdir1/subdir2; cp TEST-panel-servable.ipynb subdir1/servable1.ipynb; cp TEST-panel-servable.ipynb subdir1/subdir2/servable2.ipynb; cp TEST-panel-servable.ipynb TEST-panel-servable-Copy.ipynb
+
+RUN chown jenkins:jenkins -R .
 
 # RUN pip install https://github.com/Ouranosinc/xclim/archive/master.tar.gz
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:220407.1
+FROM pavics/workflow-tests:220412
 
 USER root
 

--- a/binder/test-notebooks/TEST-panel-binder.ipynb
+++ b/binder/test-notebooks/TEST-panel-binder.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d79b1053-3144-47d4-824f-49a3666d68e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:bokeh.server.util:Host wildcard '*' will allow connections originating from multiple (or possibly all) hostnames or IPs. Use non-wildcard values to restrict access explicitly\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Launching server at http://localhost:5007\n"
+     ]
+    }
+   ],
+   "source": [
+    "import panel as pn\n",
+    "srv = pn.panel(\n",
+    "    pn.widgets.FloatInput(name='an input')\n",
+    ").show(port=5007, websocket_origin=\"*\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f18de16-80bd-40dc-9438-ca176fc8c169",
+   "metadata": {},
+   "source": [
+    "Your current URL should look something like:\n",
+    "\n",
+    "https://hub.gke2.mybinder.org/user/ouranosinc-pavi--workflow-tests-9jerf8qk/lab/tree/TEST-panel-binder.ipynb\n",
+    "\n",
+    "Open a new browser tab, then to go to something like this URL (replace `lab/tree/TEST-panel-binder.ipynb` with `proxy/5007/`):\n",
+    "\n",
+    "https://hub.gke2.mybinder.org/user/ouranosinc-pavi--workflow-tests-9jerf8qk/proxy/5007/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d39a37c-8df6-4f27-9aeb-54181f35c295",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "srv.stop()  # To stop the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb898f21-f543-40b4-8bf4-b701559b842f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/binder/test-notebooks/TEST-panel-servable.ipynb
+++ b/binder/test-notebooks/TEST-panel-servable.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7acdd82a-bc2d-443c-8fa8-e432de9cfa30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "pn.panel('# Ceci est un test').servable()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,9 @@ RUN python -m ipykernel install --name birdy
 # https://github.com/plotly/jupyter-dash/issues/49
 RUN jupyter lab build
 
-RUN jupyter serverextension enable voila --sys-prefix
+RUN jupyter serverextension enable voila --sys-prefix \
+    && jupyter serverextension enable panel.io.jupyter_server_extension --sys-prefix \
+    && jupyter serverextension list
 #    && jupyter labextension install jupyterlab-clipboard
 
 # This should be "master" but commit

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,11 +106,6 @@ ENV BOKEH_ALLOW_WS_ORIGIN "*"
 # the jupyter/base-notebook image also do not default to root user so we do the same here
 USER jenkins
 
-# Patch Panel for "Render with Panel" button regression fix
-# TODO remove this patch once a Panel release contain this PR https://github.com/holoviz/panel/pull/3469.
-RUN wget https://raw.githubusercontent.com/tlvu/panel/ac8d6fb3efdfb66315af1107070a6c67affaebc8/panel/io/jupyter_server_extension.py \
-    -O /opt/conda/envs/birdy/lib/python3.8/site-packages/panel/io/jupyter_server_extension.py
-
 # follow jupyter/base-notebook image so config in jupyterhub is simpler
 # start notebook in conda environment to have working jupyter extensions
 CMD ["conda", "run", "-n", "birdy", "/usr/local/bin/start-notebook.sh"]

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -55,7 +55,7 @@ dependencies:
   - jupyter_bokeh
   - pscript
   - h5netcdf
-  - panel >= 0.13.1a2
+  - panel >= 0.13.1a3
   # https://github.com/holoviz/panel
   - pyviz_comms  # (was labextension pyviz/jupyterlab_pyviz in jupyterlab v2)
   - holoviews

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -170,6 +170,10 @@ dependencies:
   # xeus-python: back-end kernel implementing the Jupyter Debug Protocol
   - xeus-python
   - jupyter-dash
+  # https:://github.com/jupyterhub/jupyter-server-proxy
+  - jupyter-server-proxy
+  # https://github.com/dask/dask-labextension
+  - dask-labextension
   # Force newer nodejs for 'jupyter lab build' issue
   # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998901247
   # TODO: remove nodejs once all extensions move to prebuilt extensions, see comment

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -5,6 +5,7 @@ channels:
   - cdat
   - bokeh
   - plotly  # for jupyter-dash
+  - pyviz  # for jupyter-panel-proxy
   - defaults
 
 dependencies:
@@ -174,6 +175,8 @@ dependencies:
   - jupyter-server-proxy
   # https://github.com/dask/dask-labextension
   - dask-labextension
+  # https://github.com/holoviz/jupyter-panel-proxy
+  - jupyter-panel-proxy
   # Force newer nodejs for 'jupyter lab build' issue
   # https://github.com/jupyterlab/jupyterlab/issues/11726#issuecomment-998901247
   # TODO: remove nodejs once all extensions move to prebuilt extensions, see comment

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220407"
+    DOCKER_IMAGE="pavics/workflow-tests:220407.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220401"
+    DOCKER_IMAGE="pavics/workflow-tests:220407"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220412"
+    DOCKER_IMAGE="pavics/workflow-tests:220414"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220407.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220412"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220401"
+    DOCKER_IMAGE="pavics/workflow-tests:220407"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220407.1"
+    DOCKER_IMAGE="pavics/workflow-tests:220412"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220412"
+    DOCKER_IMAGE="pavics/workflow-tests:220414"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:220407"
+    DOCKER_IMAGE="pavics/workflow-tests:220407.1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
# Overview

Still have to pin `dask` for performance and `shapely` for notebook error.

Dask dashboard and Panel server app work both by manually mapping `http://localhost:<PORT>` to `https://pavics.ouranos.ca/jupyter/user/<USER>/proxy/<PORT>` as seen in screenshots below:

![Screenshot from 2022-04-12 15-20-58](https://user-images.githubusercontent.com/11966697/163259294-97337abd-91e6-4832-b639-d7d2e89c353d.png) 

![Screenshot from 2022-04-12 16-29-06](https://user-images.githubusercontent.com/11966697/163264000-c2d0f993-8d4d-4eeb-8fa7-0cdce454c2f4.png)

The "Render with Panel" green button also works and avoid having to deal with manual URL rewrite:
![Screenshot from 2022-05-04 15-18-03](https://user-images.githubusercontent.com/11966697/166810160-f6989da4-6e8f-4407-8fd5-4ef71770e1f2.png)


## Relevant Changes

```diff
# new
>   - dask-labextension=5.2.0=pyhd8ed1ab_0
>   - jupyter-panel-proxy=0.2.0a2=py_0
>   - jupyter-server-proxy=3.2.1=pyhd8ed1ab_0

# removed, interfere with panel
<     - handcalcs==1.4.1

<   - xclim=0.34.0=pyhd8ed1ab_0
>   - xclim=0.36.0=pyhd8ed1ab_0

<   - cf_xarray=0.6.3=pyhd8ed1ab_0
>   - cf_xarray=0.7.2=pyhd8ed1ab_0

<   - clisops=0.8.0=pyh6c4a22f_0
>   - clisops=0.9.0=pyh6c4a22f_0

# downgrade by clisops
<   - pandas=1.4.1=py38h43a58ef_0
>   - pandas=1.3.5=py38h43a58ef_0

<   - rioxarray=0.10.3=pyhd8ed1ab_0
>   - rioxarray=0.11.1=pyhd8ed1ab_0

<   - nc-time-axis=1.4.0=pyhd8ed1ab_0
>   - nc-time-axis=1.4.1=pyhd8ed1ab_0

<   - roocs-utils=0.5.0=pyh6c4a22f_0
>   - roocs-utils=0.6.1=pyh6c4a22f_0

<   - panel=0.12.7=pyhd8ed1ab_0
>   - panel=0.13.1a2=py_0

<   - plotly=5.6.0=pyhd8ed1ab_0
>   - plotly=5.7.0=pyhd8ed1ab_0
```

## Related Issue / Discussion

- https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/99
- https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/100
- PR to deploy this new Jupyter env to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/241
- https://github.com/bokeh/bokeh/issues/12090
- https://github.com/holoviz/jupyter-panel-proxy/issues/21
- https://github.com/holoviz/panel/pull/3469
- https://github.com/holoviz/panel/issues/3440

## Test

* Deployed as "beta" image in production for bokeh visualization performance regression testing.

* Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.

* Jenkins builds: only known subset-user-input.ipynb: ​RemoteDisconnected, `pavics/workflow-tests:220412`: 
  [job-PAVICS-e2e-workflow-tests-new-docker-build-17-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8484558/job-PAVICS-e2e-workflow-tests-new-docker-build-17-consoleText.txt)
  [job-PAVICS-e2e-workflow-tests-new-docker-build-16-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8484559/job-PAVICS-e2e-workflow-tests-new-docker-build-16-consoleText.txt)
  [job-PAVICS-e2e-workflow-tests-new-docker-build-15-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8484560/job-PAVICS-e2e-workflow-tests-new-docker-build-15-consoleText.txt)

* Jenkins build: all passed, `pavics/workflow-tests:220522`:
climex.ipynb 2.5 mins, OK [job-PAVICS-e2e-workflow-tests-new-docker-build-39-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8627256/job-PAVICS-e2e-workflow-tests-new-docker-build-39-consoleText.txt)
climex.ipynb 5 mins, Slow [job-PAVICS-e2e-workflow-tests-new-docker-build-41-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8627258/job-PAVICS-e2e-workflow-tests-new-docker-build-41-consoleText.txt)
climex.ipynb 14 mins, VERY Slow [job-PAVICS-e2e-workflow-tests-new-docker-build-42-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8627789/job-PAVICS-e2e-workflow-tests-new-docker-build-42-consoleText.txt)





## Additional Information

* Full diff `conda env export`:
[220401-220412-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8484573/220401-220412-conda-env-export.diff.txt)

  [220401-220502-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8627790/220401-220502-conda-env-export.diff.txt)


* Full new `conda env export`:
[220412-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8484577/220412-conda-env-export.yml.txt)

  [220502-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/8627792/220502-conda-env-export.yml.txt)

