### PR TITLE
New Jupyter env docker build for urlpath

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:221118.1"
+            image "pavics/workflow-tests:221130"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:221118.1
+FROM pavics/workflow-tests:221130
 
 USER root
 

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -209,3 +209,4 @@ dependencies:
     # Needed to run notebook tests.  Missing indirect recursive dependencies
     # somewhere, should not need to manually add it here.
     - pytest-tornasync
+    - urlpath

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -176,6 +176,9 @@ dependencies:
   - curl
   - wget
   - nested_dict
+  # https://anaconda.org/conda-forge/urlpath
+  # https://github.com/brandonschabell/urlpath
+  - urlpath
   - paramiko
   - pymetalink  # for Raven notebook Extract_geographical_watershed_properties.ipynb
   - requests-magpie
@@ -209,4 +212,3 @@ dependencies:
     # Needed to run notebook tests.  Missing indirect recursive dependencies
     # somewhere, should not need to manually add it here.
     - pytest-tornasync
-    - urlpath

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:221118.1"
+    DOCKER_IMAGE="pavics/workflow-tests:221130"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:221118.1"
+    DOCKER_IMAGE="pavics/workflow-tests:221130"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
# Overview

Full rebuild to add `urlpath`.  Previous rebuild was https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/106.

## Changes

- Adds `urlpath` for https://github.com/Ouranosinc/pavics-sdi/pull/268, fixes https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/110
- Relevant changes (alphabetical order):
```diff
<   - climpred=2.2.0=pyhd8ed1ab_0
>   - climpred=2.3.0=pyhd8ed1ab_0

<   - dask=2022.11.0=pyhd8ed1ab_0
>   - dask=2022.11.1=pyhd8ed1ab_0

<   - flox=0.6.3=pyhd8ed1ab_0
>   - flox=0.6.4=pyhd8ed1ab_0

<   - h5netcdf=1.0.2=pyhd8ed1ab_0
>   - h5netcdf=1.1.0=pyhd8ed1ab_0

<   - numpy=1.23.4=py38h7042d01_1
>   - numpy=1.23.5=py38h7042d01_0

>   - urlpath=1.2.0=pyhd8ed1ab_0
```

## Test

- Deployed as "alpha" image in production for bokeh visualization performance regression testing.

- Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.

- Jenkins build: all passed except known esgf-dap.ipynb:
[job-PAVICS-e2e-workflow-tests-new-docker-build-121-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/10232109/job-PAVICS-e2e-workflow-tests-new-docker-build-121-consoleText.txt)



## Related Issue / Discussion

- Deployment to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/271

## Additional Information

- Full diff `conda env export`:
[221118.1-221130-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/10232126/221118.1-221130-conda-env-export.diff.txt)

- Full new `conda env export`:
[221130-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/10232133/221130-conda-env-export.yml.txt)

- DockerHub build logs:
[Dockerhub-buildlogs-pavics-workflow-tests-221130.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/10232160/Dockerhub-buildlogs-pavics-workflow-tests-221130.txt)

