### PR TITLE
Jupyter docker: new build for esgf-pyclient, xncml, globus personal connect and latest of everything else

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:221130"
+            image "pavics/workflow-tests:230121"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:230217-update230221"
+            image "pavics/workflow-tests:230217-update230221-1"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:230209"
+            image "pavics/workflow-tests:230217"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:230217"
+            image "pavics/workflow-tests:230217-update230221"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:230121"
+            image "pavics/workflow-tests:230209"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:230121
+FROM pavics/workflow-tests:230209
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:230217
+FROM pavics/workflow-tests:230217-update230221
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:230209
+FROM pavics/workflow-tests:230217
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:230217-update230221
+FROM pavics/workflow-tests:230217-update230221-1
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:221130
+FROM pavics/workflow-tests:230121
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,6 +111,10 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_
 # For jupyter-panel-proxy launcher.
 ENV BOKEH_ALLOW_WS_ORIGIN "*"
 
+# For import xesmf since esmf-8.4.0, see
+# https://github.com/conda-forge/esmf-feedstock/issues/91
+ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
+
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here
 USER jenkins

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,7 +102,6 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_
     chmod a+rwX -R /opt/conda/envs/birdy/fonts && \
     chmod a+rwX -R /opt/conda/pkgs/cache && \
     chown jenkins:jenkins -R /opt/conda/pkgs/cache && \
-    chmod a+rwX -R /opt/conda/envs/birdy/share/proj && \
     mkdir -p /usr/local/bin && \
     wget https://downloads.globus.org/globus-connect-personal/linux/stable/globusconnectpersonal-latest.tgz -O /usr/local/bin/globusconnectpersonal-latest.tgz && \
     tar xzf /usr/local/bin/globusconnectpersonal-latest.tgz -C /usr/local/bin/ && \
@@ -115,6 +114,11 @@ ENV BOKEH_ALLOW_WS_ORIGIN "*"
 # For import xesmf since esmf-8.4.0, see
 # https://github.com/conda-forge/esmf-feedstock/issues/91
 ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
+
+# To avoid error "PROJ: proj_create_from_database: Open of
+# /opt/conda/envs/birdy/share/proj failed"
+# This simulates a real `conda activate birdy`.
+ENV PROJ_DATA="/opt/conda/envs/birdy/share/proj"
 
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,12 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_
     mkdir /notebook_dir && chown jenkins /notebook_dir && \
     chmod a+rwX -R /opt/conda/envs/birdy/fonts && \
     chmod a+rwX -R /opt/conda/pkgs/cache && \
-    chown jenkins:jenkins -R /opt/conda/pkgs/cache
+    chown jenkins:jenkins -R /opt/conda/pkgs/cache && \
+    mkdir -p /usr/local/bin && \
+    wget https://downloads.globus.org/globus-connect-personal/linux/stable/globusconnectpersonal-latest.tgz -O /usr/local/bin/globusconnectpersonal-latest.tgz && \
+    tar xzf /usr/local/bin/globusconnectpersonal-latest.tgz -C /usr/local/bin/ && \
+    ln -vs /usr/local/bin/globusconnectpersonal*/globusconnectpersonal /usr/local/bin/globusconnectpersonal && \
+    rm -v /usr/local/bin/globusconnectpersonal-latest.tgz
 
 # For jupyter-panel-proxy launcher.
 ENV BOKEH_ALLOW_WS_ORIGIN "*"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,6 +102,7 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_
     chmod a+rwX -R /opt/conda/envs/birdy/fonts && \
     chmod a+rwX -R /opt/conda/pkgs/cache && \
     chown jenkins:jenkins -R /opt/conda/pkgs/cache && \
+    chmod a+rwX -R /opt/conda/envs/birdy/share/proj && \
     mkdir -p /usr/local/bin && \
     wget https://downloads.globus.org/globus-connect-personal/linux/stable/globusconnectpersonal-latest.tgz -O /usr/local/bin/globusconnectpersonal-latest.tgz && \
     tar xzf /usr/local/bin/globusconnectpersonal-latest.tgz -C /usr/local/bin/ && \

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -4,7 +4,9 @@ FROM pavics/workflow-tests:230217
 
 ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
 
-#USER root
+USER root
+
+RUN chmod a+rwX -R /opt/conda/envs/birdy/share/proj
 
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
@@ -22,4 +24,4 @@ ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip
 
-#USER jenkins
+USER jenkins

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -4,9 +4,9 @@ FROM pavics/workflow-tests:230217
 
 ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
 
-USER root
+ENV PROJ_DATA="/opt/conda/envs/birdy/share/proj"
 
-RUN chmod a+rwX -R /opt/conda/envs/birdy/share/proj
+#USER root
 
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
@@ -24,4 +24,4 @@ RUN chmod a+rwX -R /opt/conda/envs/birdy/share/proj
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip
 
-USER jenkins
+#USER jenkins

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,13 +1,15 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:220728
+FROM pavics/workflow-tests:230217
 
-USER root
+ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
+
+#USER root
 
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
-RUN umask 0000 \
-    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyston -c pyviz/label/dev -c defaults -n birdy geopy
+#RUN umask 0000 \
+#    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyston -c pyviz/label/dev -c defaults -n birdy geopy
 #    && pip uninstall -y ravenpy \
 #    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 
@@ -20,4 +22,4 @@ RUN umask 0000 \
 #RUN umask 0000 \
 #    && pip install https://github.com/CSHS-CWRA/RavenPy/archive/refs/heads/master.zip
 
-USER jenkins
+#USER jenkins

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -120,6 +120,8 @@ dependencies:
   - memory_profiler
   # for esgf notebooks
   - esgf-compute-api
+  # https://anaconda.org/conda-forge/esgf-pyclient (for pavics-sdi esgf-dap.ipynb)
+  - esgf-pyclient
   - cdms2
   # Disable vcs because it was forcing python downgrade to below 3.9.
   # See https://github.com/CDAT/vcs/issues/457

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -194,6 +194,9 @@ dependencies:
   # for pip packages
   - pip
   - pip:
+    # https://pypi.org/project/xncml/
+    # Tools for manipulating and opening NCML (NetCDF Markup) files with/for xarray
+    - xncml
     # visual debugger for Jupyter Notebook, not working with JupyterLab at this moment
     - pixiedust
     # block execution of 'run_all_cells' until user input finished

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230217"
+    DOCKER_IMAGE="pavics/workflow-tests:230217-update230221"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:221130"
+    DOCKER_IMAGE="pavics/workflow-tests:230121"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230121"
+    DOCKER_IMAGE="pavics/workflow-tests:230209"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230217-update230221"
+    DOCKER_IMAGE="pavics/workflow-tests:230217-update230221-1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230209"
+    DOCKER_IMAGE="pavics/workflow-tests:230217"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230209"
+    DOCKER_IMAGE="pavics/workflow-tests:230217"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230121"
+    DOCKER_IMAGE="pavics/workflow-tests:230209"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:221130"
+    DOCKER_IMAGE="pavics/workflow-tests:230121"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230217"
+    DOCKER_IMAGE="pavics/workflow-tests:230217-update230221"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230217-update230221"
+    DOCKER_IMAGE="pavics/workflow-tests:230217-update230221-1"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
## Changes

- Adds `esgf-pyclient` for esgf-dap.ipynb (https://github.com/Ouranosinc/pavics-sdi/pull/269)
- Adds `xncml` for gen_catalog refactoring (https://github.com/Ouranosinc/pavics-vdb/pull/46)
- Adds Globus Personnal Connect to be able to transfer big files in and out of the Jupyter env
- Fixes annoying harmless error `ERROR 1: PROJ: proj_create_from_database: Open of /opt/conda/envs/birdy/share/proj failed`
- Relevant changes (alphabetical order):

## Test

- Deployed as "alpha" image in production for bokeh visualization performance regression testing.
- Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.
- Jenkins build: 

## Related Issue / Discussion

- Matching notebook fixes:
- Deployment to PAVICS:

## Additional Information

Full diff conda env export:

Full new conda env export:

DockerHub build logs: