### PR TITLE
Remove WPS name in output paths

### DIFF
--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -71,17 +71,17 @@ replace: 100% Done |  1.0s
 
 [travis-ci_wps_output_url]
 # output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
-regex: http://localhost:\d+/outputs/
+regex: http://localhost:\d+/outputs/(?:(?:finch)|(?:weaver)/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [local-run_wps_output_url]
 # <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmpirlo_k7d.png" width="400"/>
-regex: http://127\.0\.0\.1:\d+/outputs/
+regex: http://127\.0\.0\.1:\d+/outputs/(?:(?:finch)|(?:weaver)/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [production_wps_output_url]
 # output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
-regex: https://[a-z0-9_\-\.]+/wpsoutputs/
+regex: https://[a-z0-9_\-\.]+/wpsoutputs/(?:(?:finch)|(?:weaver)/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [finch-nb-temp-folder]

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -71,17 +71,17 @@ replace: 100% Done |  1.0s
 
 [travis-ci_wps_output_url]
 # output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
-regex: http://localhost:\d+/outputs/(?:[a-z-_]*/)?
+regex: http://localhost:\d+/outputs/(?:[a-z\-\_]*/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [local-run_wps_output_url]
 # <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmpirlo_k7d.png" width="400"/>
-regex: http://127\.0\.0\.1:\d+/outputs/(?:[a-z-_]*/)?
+regex: http://127\.0\.0\.1:\d+/outputs/(?:[a-z\-\_]*/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [production_wps_output_url]
 # output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
-regex: https://[a-z0-9_\-\.]+/wpsoutputs/(?:[a-z-_]*/)?
+regex: https://[a-z0-9_\-\.]+/wpsoutputs/(?:[a-z\-\_]*/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [finch-nb-temp-folder]

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -71,17 +71,17 @@ replace: 100% Done |  1.0s
 
 [travis-ci_wps_output_url]
 # output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
-regex: http://localhost:\d+/outputs/(?:(?:finch)|(?:weaver)/)?
+regex: http://localhost:\d+/outputs/(?:(?:finch/)|(?:weaver/))?
 replace: https://WPS_HOST/wpsoutputs/
 
 [local-run_wps_output_url]
 # <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmpirlo_k7d.png" width="400"/>
-regex: http://127\.0\.0\.1:\d+/outputs/(?:(?:finch)|(?:weaver)/)?
+regex: http://127\.0\.0\.1:\d+/outputs/(?:(?:finch/)|(?:weaver/))?
 replace: https://WPS_HOST/wpsoutputs/
 
 [production_wps_output_url]
 # output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
-regex: https://[a-z0-9_\-\.]+/wpsoutputs/(?:(?:finch)|(?:weaver)/)?
+regex: https://[a-z0-9_\-\.]+/wpsoutputs/(?:(?:finch/)|(?:weaver/))?
 replace: https://WPS_HOST/wpsoutputs/
 
 [finch-nb-temp-folder]

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -71,17 +71,17 @@ replace: 100% Done |  1.0s
 
 [travis-ci_wps_output_url]
 # output_netcdf='http://localhost:5000/outputs/50c0a3f8-67c7-11ea-9e2d-b06ebf31cced/frost-days_SRES-A2-experiment_20460101-20650101.nc
-regex: http://localhost:\d+/outputs/(?:(?:finch/)|(?:weaver/))?
+regex: http://localhost:\d+/outputs/(?:[a-z-_]*/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [local-run_wps_output_url]
 # <img src="http://127.0.0.1:8093/outputs/STATUS_FILE/tmpirlo_k7d.png" width="400"/>
-regex: http://127\.0\.0\.1:\d+/outputs/(?:(?:finch/)|(?:weaver/))?
+regex: http://127\.0\.0\.1:\d+/outputs/(?:[a-z-_]*/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [production_wps_output_url]
 # output_netcdf='https://pavics.ouranos.ca/wpsoutputs/e8afbb04-42d3-11ea-9531-0242ac12000b/out.nc
-regex: https://[a-z0-9_\-\.]+/wpsoutputs/(?:(?:finch/)|(?:weaver/))?
+regex: https://[a-z0-9_\-\.]+/wpsoutputs/(?:[a-z-_]*/)?
 replace: https://WPS_HOST/wpsoutputs/
 
 [finch-nb-temp-folder]


### PR DESCRIPTION
Remove WPS name from output url for notebook testing

This replaces bird-house/finch#273 as a solution for the change in output paths in wps outputs.

The previous solution was breaking finch's CI. pyWPS wants "outputpath" and "outputurl" to match. This means that if "outputurl" has two levels, "outputpath" must have the same second level. But, when developing and testing (both locally and on the CI) "outputpath" is not explicitly set, thus is the default, thus does not match "outputurl"'s second level.  The previous solution was patching the notebooks directly when generating them, but nothing of the sort was done in the test suite, which then failed.

The proper way to fix this in the testing is this sanitizing file, thus I am suggesting to take care of the path issue here directly, and _only_ here.

The related rollback in finch will be done in bird-house/finch#272.