### PR TITLE
Jupyter docker: incremental build to add esgf-pyclient and xncml to fix Jenkins failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:221130"
+            image "pavics/workflow-tests:221130-update230403"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,9 +136,8 @@ Note this is another run, will double the time and no guaranty to have same erro
         ansiColor('xterm')
         timestamps()
         timeout(time: 2, unit: 'HOURS')
-        // trying to keep 2 months worth of history with buffer for manual
-        // build trigger on failed builds or manual test after each production
-        // deployment or test deployment
-        buildDiscarder(logRotator(numToKeepStr: '200'))
+        // trying to keep 3 months worth of history
+        // assuming manual build requests are done on a separated job
+        buildDiscarder(logRotator(numToKeepStr: '100'))
     }
 }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:221130
+FROM pavics/workflow-tests:221130-update230403
 
 USER root
 

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,13 +1,20 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:220728
+FROM pavics/workflow-tests:221130
+
+# To avoid error "PROJ: proj_create_from_database: Open of /opt/conda/envs/birdy/share/proj failed"
+# This simulates a real `conda activate birdy`.
+ENV PROJ_DATA="/opt/conda/envs/birdy/share/proj"
 
 USER root
 
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
+# esgf-pyclient for pavics-sdi esgf-dap.ipynb, PR https://github.com/Ouranosinc/pavics-sdi/pull/269
+# xncml for gen_catalog refactoring, PR https://github.com/Ouranosinc/pavics-vdb/pull/46
 RUN umask 0000 \
-    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyston -c pyviz/label/dev -c defaults -n birdy geopy
+    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyston -c pyviz/label/dev -c defaults -n birdy esgf-pyclient \
+    && pip install xncml
 #    && pip uninstall -y ravenpy \
 #    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp
 

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:221130"
+    DOCKER_IMAGE="pavics/workflow-tests:221130-update230403"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:221130"
+    DOCKER_IMAGE="pavics/workflow-tests:221130-update230403"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
# Overview

This is a build on top of an existing build.  A fresh full build because it would pull a newer RavenPy which would requires a newer RavenWPS, which do not start at this moment.

This incremental build is faster to test and will fix our failing Jenkins due to missing package `esgf-pyclient`.

It is annoying to have Jenkins failing since a while just for a missing package.

## Changes

- Adds `esgf-pyclient` for esgf-dap.ipynb (https://github.com/Ouranosinc/pavics-sdi/pull/269)
- Adds `xncml` for gen_catalog refactoring (https://github.com/Ouranosinc/pavics-vdb/pull/46)
- Fixes annoying harmless error `ERROR 1: PROJ: proj_create_from_database: Open of /opt/conda/envs/birdy/share/proj failed`
- Jenkins: lower job retention duration since we now have separated jobs for nightly trigger and manual trigger
- Existing `intake-esm` pin: https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/109
- Relevant changes (alphabetical order):
```diff
>   - esgf-pyclient=0.3.1=pyh1a96a4e_2

<   - gdal=3.5.3=py38h1f15b03_4
>   - gdal=3.6.0=py38h58634bd_13

>     - xncml==0.2
```

## Test

- Deployed as "beta" image in production for bokeh visualization performance regression testing.
- Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.
- Jenkins build: one known intermittent error
[job-PAVICS-e2e-workflow-tests-quick-fix-production-image-3-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/11151086/job-PAVICS-e2e-workflow-tests-quick-fix-production-image-3-consoleText.txt)

## Related Issue / Discussion

- Matching notebook fixes:
  - Pavics-sdi: https://github.com/Ouranosinc/pavics-sdi/pull/285

- Deployment to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/308

## Additional Information

Full diff conda env export:
[221130-221130-update230403-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/11151115/221130-221130-update230403-conda-env-export.diff.txt)


Full new conda env export:
[221130-update230403-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/11151116/221130-update230403-conda-env-export.yml.txt)


DockerHub build logs:
[Dockerhub-buildlogs-pavics-workflow-tests-221130-update230403.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/11151131/Dockerhub-buildlogs-pavics-workflow-tests-221130-update230403.txt)
