### PR TITLE
Jupyter docker: new build for RavenPy 0.12.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:230530-1-update230601"
+            image "pavics/workflow-tests:230601"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:230530-1"
+            image "pavics/workflow-tests:230530-1-update230601"
             label 'linux && docker'
         }
     }

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:230530-1-update230601
+FROM pavics/workflow-tests:230601
 
 USER root
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:230530-1
+FROM pavics/workflow-tests:230530-1-update230601
 
 USER root
 

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -7,9 +7,9 @@
 
 rm -r esgf-compute-api-$ESGF_COMPUTE_API_BRANCH
 
-mkdir raven
-mv -v raven-${RAVEN_BRANCH}/docs/source/notebooks/*.ipynb ./raven/
-mv -v RavenPy-${RAVENPY_BRANCH}/docs/notebooks/*.ipynb ./raven/
+mkdir hydro
+mv -v raven-${RAVEN_BRANCH}/docs/source/notebooks/*.ipynb ./hydro/
+mv -v RavenPy-${RAVENPY_BRANCH}/docs/notebooks/*.ipynb ./hydro/
 rm -r raven-${RAVEN_BRANCH} RavenPy-${RAVENPY_BRANCH}
 
 if [ -n "$DEPLOY_PAVICS_LANDING_NB" ]; then

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,6 +1,6 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:230526-1
+FROM pavics/workflow-tests:230530-1
 
 #ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
 
@@ -11,7 +11,7 @@ USER root
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
 RUN umask 0000 \
-    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyviz/label/dev -c defaults -n birdy numpy==1.23.5 pytest-xdist \
+    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyviz/label/dev -c defaults -n birdy ravenpy==0.12.1 \
     && mamba clean --all --yes
 #    && pip uninstall -y ravenpy \
 #    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   # Pin latest xclim and ravenpy to avoid downgrading during the second installation phase.
   # Mamba is quicker to solve dependencies than conda, but it is less precise so accidental downgrades can happen.
   - xclim >= 0.43.0
-  - ravenpy >= 0.12.0
+  - ravenpy >= 0.12.1
 
     #- dask  # from xclim and ravenpy
     #- distributed

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230530-1"
+    DOCKER_IMAGE="pavics/workflow-tests:230530-1-update230601"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230530-1-update230601"
+    DOCKER_IMAGE="pavics/workflow-tests:230601"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230530-1"
+    DOCKER_IMAGE="pavics/workflow-tests:230530-1-update230601"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230530-1-update230601"
+    DOCKER_IMAGE="pavics/workflow-tests:230601"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
## Changes

- Rename `raven` folder in deployed tutorial notebooks on PAVICS to `hydro`.
- Pull latest RavenPy 0.12.1
- Relevant changes (alphabetical order):
```diff
<   - datashader=0.14.4=pyh1a96a4e_0
>   - datashader=0.15.0=pyhd8ed1ab_0

<   - ravenpy=0.12.0=py39hf3d152e_2
>   - ravenpy=0.12.1=py39hf3d152e_0

<   - regionmask=0.9.0=pyhd8ed1ab_0
>   - regionmask=0.10.0=pyhd8ed1ab_0

```

## Tesst

* Deployed as "beta" image in production for bokeh visualization performance regression testing.
* Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.
* Jenkins build:

## Related Issue / Discussion

* No notebook changes required:

* Deployment to PAVICS:

## Additional Information

Full diff conda env export:

Full new conda env export:

Docker build log:
