### PR TITLE
Jupyter docker: incremental build to add SAlib for new RavenPY nb Sensitivity_analysis.ipynb

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,16 +4,60 @@ Please include a summary of the changes and which issues is fixed. Please also i
 
 This PR fixes [issue id](url)
 
+
 ## Changes
 
 - Adds...
+- Jupyter env changes:
+  - Change 1 (related PR url)
+  - Change 2 (related PR url)
+  - Relevant changes (alphabetical order):
+```diff
+<   - birdy=0.8.1=pyh6c4a22f_1
+>   - birdy=0.8.4=pyh1a96a4e_0
+
+(...)
+
+```
+
+
+## Test
+
+- Deployed as "beta" image in production for bokeh visualization performance regression testing.
+- Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.
+- Jenkins build, all passed:
+  - To upload `job-PAVICS-e2e-workflow-tests-new-docker-build-###-consoleText.txt`
+  - To upload `ravenpy-job-PAVICS-e2e-workflow-tests-new-docker-build-###-consoleText.txt`
+
 
 ## Related Issue / Discussion
 
-- Resolves ...
+- Matching notebook fixes:
+  - Pavics-sdi: PR url
+  - Finch: PR url
+  - PAVICS-landing: PR url
+  - RavenPy: PR url
+  - (...)
+
+- Deployment to PAVICS: PR url
+
+- Jenkins-config changes for new notebooks: PR url
+
+- Other issues found while working on this one
+  - Issue 1 URL
+  - Issue 2 URL
+  - (...)
+
+- Previous release: PR url
+
 
 ## Additional Information
 
-Links to other issues or sources.
+Full diff conda env export:
+To upload `OLD_TAG-NEW_TAG-conda-env-export.diff.txt`
 
-- [ ] Things to do...
+Full new conda env export:
+To upload `NEW_TAG-conda-env-export.yml.txt`
+
+DockerHub build log
+To upload `NEW_TAG-buildlogs.txt`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,8 @@ This PR fixes [issue id](url)
   - Change 2 (related PR url)
   - Relevant changes (alphabetical order):
 ```diff
-<   - birdy=0.8.1=pyh6c4a22f_1
->   - birdy=0.8.4=pyh1a96a4e_0
+<   - somelib=0.8.1=pyh6c4a22f_1
+>   - somelib=0.8.4=pyh1a96a4e_0
 
 (...)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     // https://jenkins.io/doc/book/pipeline/syntax/
     agent {
         docker {
-            image "pavics/workflow-tests:230601"
+            image "pavics/workflow-tests:py39-230601-1-update231025"
             label 'linux && docker'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ Requires 'weaver' component to be active on the target 'PAVICS_HOST' server
                description: 'https://github.com/Ouranosinc/PAVICS-landing repo or fork to test against.', trim: true)
         booleanParam(name: 'TEST_RAVEN_REPO', defaultValue: false,
                      description: 'Check the box to test raven repo.')
-        string(name: 'RAVEN_BRANCH', defaultValue: 'master',
+        string(name: 'RAVEN_BRANCH', defaultValue: 'main',
                description: 'RAVEN_REPO branch to test against.', trim: true)
         string(name: 'RAVEN_REPO', defaultValue: 'Ouranosinc/raven',
                description: 'https://github.com/Ouranosinc/raven repo or fork to test against.', trim: true)

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,4 +1,4 @@
-FROM pavics/workflow-tests:230601
+FROM pavics/workflow-tests:py39-230601-1-update231025
 
 USER root
 

--- a/default_build_params
+++ b/default_build_params
@@ -71,7 +71,7 @@ else
 fi
 
 if [ -z "$RAVEN_BRANCH" ]; then
-    RAVEN_BRANCH=master
+    RAVEN_BRANCH=main
     echo "RAVEN_BRANCH not set, default to '$RAVEN_BRANCH'"
 else
     echo "RAVEN_BRANCH has been set to '$RAVEN_BRANCH'"

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -1,6 +1,6 @@
 # For testing quickly without having to do a full rebuild.
 
-FROM pavics/workflow-tests:230530-1
+FROM pavics/workflow-tests:py39-230601-1
 
 #ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
 
@@ -11,7 +11,7 @@ USER root
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
 RUN umask 0000 \
-    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyviz/label/dev -c defaults -n birdy ravenpy==0.12.1 \
+    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c pyviz/label/dev -c defaults -n birdy salib \
     && mamba clean --all --yes
 #    && pip uninstall -y ravenpy \
 #    && mamba install -c conda-forge -c cdat -c bokeh -c plotly -c defaults -n birdy ravenpy aiohttp

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -127,6 +127,9 @@ dependencies:
   # https://github.com/pangeo-data/xESMF
   # xesmf-0.6.2 requires clisops>=0.8.0
   - xesmf >= 0.6.2
+  # Sensitivity Analysis Library
+  # https://anaconda.org/conda-forge/salib
+  - salib
   # https://anaconda.org/conda-forge/geopy
   - geopy
   # https://anaconda.org/anaconda/memory_profiler

--- a/launchcontainer
+++ b/launchcontainer
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230601"
+    DOCKER_IMAGE="pavics/workflow-tests:py39-230601-1-update231025"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then

--- a/launchnotebook
+++ b/launchnotebook
@@ -7,7 +7,7 @@ if [ -z "$PORT" ]; then
 fi
 
 if [ -z "$DOCKER_IMAGE" ]; then
-    DOCKER_IMAGE="pavics/workflow-tests:230601"
+    DOCKER_IMAGE="pavics/workflow-tests:py39-230601-1-update231025"
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then


### PR DESCRIPTION
# Overview

Incremental build to add SAlib for new RavenPY nb Sensitivity_analysis.ipynb https://github.com/CSHS-CWRA/RavenPy/pull/320.

Incremental build is chosen over full build to speed up release process, at the expense of not having the latest and greatest of everything.  Also because this new SAlib do not pull any new indirect dependencies which might cause incompatibility.

This PR fixes https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/127.


## Changes

- Update Github PR template for new docker build release.  To serve as reminder for other persons not used to release new Jupyter env docker images.  A lot of steps and testings are required to release a new Jupyter env docker image.
- Jenkins config: Raven default branch switched from `master` to `main`.  To fix Raven tutorial notebooks deployed to the wrong location on the Jupyter env.
- Make `/notebook_dir/` read-only to avoid users putting their files there and losing them since only `/notebook_dir/writable-workspace` is persisted on disk on a PAVICS deployment.
- Relevant changes (alphabetical order):
```diff
# New
>   - salib=1.4.7=pyhd8ed1ab_0
```


## Test

- Deployed as "beta" image in production for bokeh visualization performance regression testing.
- Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.
- Jenkins build:
  - default build, only known errors: [job-PAVICS-e2e-workflow-tests-docker-add-salib-4-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/13291608/job-PAVICS-e2e-workflow-tests-docker-add-salib-4-consoleText.txt)

  - ravenpy build, only error in the new Sensitivity_analysis.ipynb: [ravenpy-job-PAVICS-e2e-workflow-tests-docker-add-salib-3-consoleText.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/13291639/ravenpy-job-PAVICS-e2e-workflow-tests-docker-add-salib-3-consoleText.txt)



## Related Issue / Discussion

- Deployment to PAVICS: https://github.com/bird-house/birdhouse-deploy/pull/398

- Previous release: https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/119


## Additional Information

Full diff conda env export:
[py39-230601-1-py39-230601-1-update231025-conda-env-export.diff.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/13169895/py39-230601-1-py39-230601-1-update231025-conda-env-export.diff.txt)


Full new conda env export:
[py39-230601-1-update231025-conda-env-export.yml.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/13169896/py39-230601-1-update231025-conda-env-export.yml.txt)

DockerHub build log
[py39-230601-1-update231025-dockerhub-buildlogs.txt](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/files/13169919/py39-230601-1-update231025-dockerhub-buildlogs.txt)
