### PR TITLE
Add optional default config to disable some notebooks in Jenkins

### DIFF
--- a/downloadrepos
+++ b/downloadrepos
@@ -236,7 +236,7 @@ pre_saving_resulting_nb() {
 #
 # Override this function in CONFIG_OVERRIDE_SCRIPT_URL.
 #
-# USAGE: enable_resulting_nb "<filename without .ipynb ext>"
+# USAGE: enable_resulting_nb "<path/filename.ipynb"
 #
 enable_resulting_nb() {
     # Return success by default for all notebooks.

--- a/downloadrepos
+++ b/downloadrepos
@@ -159,9 +159,7 @@ post_runtest() {
 TMP_CONFIG_PARAMETERS_SCRIPT_URL=""  # init before use
 handle_config_parameters_script_url() {
 
-    if [ -n "$1" ]; then
-        TMP_CONFIG_PARAMETERS_SCRIPT_URL="$1"
-    fi
+    TMP_CONFIG_PARAMETERS_SCRIPT_URL="$1"
 
     if [ -n "$TMP_CONFIG_PARAMETERS_SCRIPT_URL" ]; then
         TMP_PARAMS_OVERRIDE="/tmp/jenkins_params_override"
@@ -191,9 +189,7 @@ handle_config_parameters_script_url() {
 TMP_CONFIG_OVERRIDE_SCRIPT_URL=""  # init before use
 handle_config_override_script_url() {
 
-    if [ -n "$1" ]; then
-        TMP_CONFIG_OVERRIDE_SCRIPT_URL="$1"
-    fi
+    TMP_CONFIG_OVERRIDE_SCRIPT_URL="$1"
 
     if [ -n "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" ]; then
         TMP_CONF_OVERRIDE="/tmp/conf_override"
@@ -201,7 +197,6 @@ handle_config_override_script_url() {
 
         CURL_EXIT_CODE=0
         if echo "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" | grep -e ^http ; then
-            # Use tee to log content of override script for traceability.
             curl --fail --silent "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" > "$TMP_CONF_OVERRIDE"
             CURL_EXIT_CODE=$?
         else

--- a/downloadrepos
+++ b/downloadrepos
@@ -211,6 +211,17 @@ handle_config_override_script_url() {
 }
 
 
+# Any pre-processing steps before generating resulting notebooks.
+#
+# Override this function in CONFIG_OVERRIDE_SCRIPT_URL to alter
+# RESULTING_NOTEBOOKS.
+#
+pre_saving_resulting_nb() {
+    # Can not have empty function, have to put something here.
+    echo "Default: no pre_saving_resulting_nb() override."
+}
+
+
 if [ -z "$DOWNLOADREPOS_AS_LIB" ]; then
     # Script mode, not library mode.
     downloadrepos_main "$@"

--- a/downloadrepos
+++ b/downloadrepos
@@ -135,6 +135,46 @@ post_runtest() {
 }
 
 
+# Allow full override of ALL Jenkins params before running test suite.
+# Intended to override all params in Jenkinsfile.
+#
+# This `CONFIG_PARAMETERS_SCRIPT_URL` is different than the
+# `CONFIG_OVERRIDE_SCRIPT_URL` in that it overrides all the
+# Jenkins params much sooner so all regular processing can take place.
+#
+# When the regular processing are not enough and we need additional
+# customizations, then we use the other `CONFIG_OVERRIDE_SCRIPT_URL`.
+#
+# The two override scripts complement each other by hooking into the
+# process at different moment in time, and together they allow full
+# complete override of the various options for the test run.
+#
+# Furthermore, CONFIG_OVERRIDE_SCRIPT_URL can also be a local file that is
+# created on the fly by CONFIG_PARAMETERS_SCRIPT_URL.  So in the end, only
+# CONFIG_PARAMETERS_SCRIPT_URL is needed for a full complete override.
+# See example in test-override/jenkins-params-raven-specific-nb.include.sh.
+#
+# USAGE: handle_config_parameters_script_url ["$CONFIG_PARAMETERS_SCRIPT_URL"]
+#
+handle_config_parameters_script_url() {
+
+    if [ -n "$1" ]; then
+        CONFIG_PARAMETERS_SCRIPT_URL="$1"
+    fi
+
+    if [ -n "$CONFIG_PARAMETERS_SCRIPT_URL" ]; then
+        TMP_PARAMS_OVERRIDE="/tmp/jenkins_params_override"
+        rm -vf "$TMP_PARAMS_OVERRIDE"
+
+        # Use tee to log content of override script for traceability.
+        curl --silent "$CONFIG_PARAMETERS_SCRIPT_URL" | tee "$TMP_PARAMS_OVERRIDE"
+
+        # Source script so it can alter ALL existing variables in the current context.
+        . "$TMP_PARAMS_OVERRIDE"
+    fi
+}
+
+
 if [ -z "$DOWNLOADREPOS_AS_LIB" ]; then
     # Script mode, not library mode.
     downloadrepos_main "$@"

--- a/downloadrepos
+++ b/downloadrepos
@@ -172,6 +172,9 @@ handle_config_parameters_script_url() {
         # Source script so it can alter ALL existing variables in the current context.
         . "$TMP_PARAMS_OVERRIDE"
     fi
+
+    # Reset for subsequent runs.
+    TMP_CONFIG_PARAMETERS_SCRIPT_URL=""
 }
 
 
@@ -208,6 +211,9 @@ handle_config_override_script_url() {
             . "$TMP_CONF_OVERRIDE"
         fi
     fi
+
+    # Reset for subsequent runs.
+    TMP_CONFIG_OVERRIDE_SCRIPT_URL=""
 }
 
 

--- a/downloadrepos
+++ b/downloadrepos
@@ -236,6 +236,19 @@ pre_saving_resulting_nb() {
 }
 
 
+# Check whether a notebook is enabled to produce output.  Can be used to
+# blacklist a list of notebooks.
+#
+# Override this function in CONFIG_OVERRIDE_SCRIPT_URL.
+#
+# USAGE: enable_resulting_nb "<filename without .ipynb ext>"
+#
+enable_resulting_nb() {
+    # Return success by default for all notebooks.
+    return 0
+}
+
+
 if [ -z "$DOWNLOADREPOS_AS_LIB" ]; then
     # Script mode, not library mode.
     downloadrepos_main "$@"

--- a/downloadrepos
+++ b/downloadrepos
@@ -175,6 +175,42 @@ handle_config_parameters_script_url() {
 }
 
 
+# Allow full override of ALL configs before running test suite.
+#
+# USAGE: handle_config_override_script_url ["$CONFIG_OVERRIDE_SCRIPT_URL"]
+#
+handle_config_override_script_url() {
+
+    if [ -n "$1" ]; then
+        CONFIG_OVERRIDE_SCRIPT_URL="$1"
+    fi
+
+    if [ -n "$CONFIG_OVERRIDE_SCRIPT_URL" ]; then
+        TMP_CONF_OVERRIDE="/tmp/conf_override"
+        rm -vf "$TMP_CONF_OVERRIDE"
+
+
+        if echo "$CONFIG_OVERRIDE_SCRIPT_URL" | grep -e ^http ; then
+            # Use tee to log content of override script for traceability.
+            curl --silent "$CONFIG_OVERRIDE_SCRIPT_URL" | tee "$TMP_CONF_OVERRIDE"
+        else
+            # Not starting with http, it's a local file.
+            # Local file can be previously created by CONFIG_PARAMETERS_SCRIPT_URL.
+            # See example in test-override/jenkins-params-raven-specific-nb.include.sh.
+            TMP_CONF_OVERRIDE="$CONFIG_OVERRIDE_SCRIPT_URL"
+
+            # Log content of override script for traceability.
+            cat "$TMP_CONF_OVERRIDE"
+        fi
+
+        # Source script so it can alter ALL existing variables in the current context.
+        if [ -f "$TMP_CONF_OVERRIDE" ]; then
+            . "$TMP_CONF_OVERRIDE"
+        fi
+    fi
+}
+
+
 if [ -z "$DOWNLOADREPOS_AS_LIB" ]; then
     # Script mode, not library mode.
     downloadrepos_main "$@"

--- a/downloadrepos
+++ b/downloadrepos
@@ -156,6 +156,7 @@ post_runtest() {
 #
 # USAGE: handle_config_parameters_script_url "$CONFIG_PARAMETERS_SCRIPT_URL"
 #
+TMP_CONFIG_PARAMETERS_SCRIPT_URL=""  # init before use
 handle_config_parameters_script_url() {
 
     if [ -n "$1" ]; then
@@ -182,6 +183,7 @@ handle_config_parameters_script_url() {
 #
 # USAGE: handle_config_override_script_url "$CONFIG_OVERRIDE_SCRIPT_URL"
 #
+TMP_CONFIG_OVERRIDE_SCRIPT_URL=""  # init before use
 handle_config_override_script_url() {
 
     if [ -n "$1" ]; then

--- a/downloadrepos
+++ b/downloadrepos
@@ -167,11 +167,16 @@ handle_config_parameters_script_url() {
         TMP_PARAMS_OVERRIDE="/tmp/jenkins_params_override"
         rm -vf "$TMP_PARAMS_OVERRIDE"
 
-        # Use tee to log content of override script for traceability.
-        curl --silent "$TMP_CONFIG_PARAMETERS_SCRIPT_URL" | tee "$TMP_PARAMS_OVERRIDE"
+        curl --fail --silent "$TMP_CONFIG_PARAMETERS_SCRIPT_URL" > "$TMP_PARAMS_OVERRIDE"
+        CURL_EXIT_CODE=$?
 
-        # Source script so it can alter ALL existing variables in the current context.
-        . "$TMP_PARAMS_OVERRIDE"
+        # Use cat to log content of override script for traceability.
+        cat "$TMP_PARAMS_OVERRIDE"
+
+        if [ $CURL_EXIT_CODE -eq 0 ]; then
+            # Source script so it can alter ALL existing variables in the current context.
+            . "$TMP_PARAMS_OVERRIDE"
+        fi
     fi
 
     # Reset for subsequent runs.
@@ -194,22 +199,23 @@ handle_config_override_script_url() {
         TMP_CONF_OVERRIDE="/tmp/conf_override"
         rm -vf "$TMP_CONF_OVERRIDE"
 
-
+        CURL_EXIT_CODE=0
         if echo "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" | grep -e ^http ; then
             # Use tee to log content of override script for traceability.
-            curl --silent "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" | tee "$TMP_CONF_OVERRIDE"
+            curl --fail --silent "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" > "$TMP_CONF_OVERRIDE"
+            CURL_EXIT_CODE=$?
         else
             # Not starting with http, it's a local file.
             # Local file can be previously created by CONFIG_PARAMETERS_SCRIPT_URL.
             # See example in test-override/jenkins-params-raven-specific-nb.include.sh.
             TMP_CONF_OVERRIDE="$TMP_CONFIG_OVERRIDE_SCRIPT_URL"
-
-            # Log content of override script for traceability.
-            cat "$TMP_CONF_OVERRIDE"
         fi
 
+        # Log content of override script for traceability.
+        cat "$TMP_CONF_OVERRIDE"
+
         # Source script so it can alter ALL existing variables in the current context.
-        if [ -f "$TMP_CONF_OVERRIDE" ]; then
+        if [ -f "$TMP_CONF_OVERRIDE" ] && [ $CURL_EXIT_CODE -eq 0 ]; then
             . "$TMP_CONF_OVERRIDE"
         fi
     fi

--- a/downloadrepos
+++ b/downloadrepos
@@ -154,20 +154,20 @@ post_runtest() {
 # CONFIG_PARAMETERS_SCRIPT_URL is needed for a full complete override.
 # See example in test-override/jenkins-params-raven-specific-nb.include.sh.
 #
-# USAGE: handle_config_parameters_script_url ["$CONFIG_PARAMETERS_SCRIPT_URL"]
+# USAGE: handle_config_parameters_script_url "$CONFIG_PARAMETERS_SCRIPT_URL"
 #
 handle_config_parameters_script_url() {
 
     if [ -n "$1" ]; then
-        CONFIG_PARAMETERS_SCRIPT_URL="$1"
+        TMP_CONFIG_PARAMETERS_SCRIPT_URL="$1"
     fi
 
-    if [ -n "$CONFIG_PARAMETERS_SCRIPT_URL" ]; then
+    if [ -n "$TMP_CONFIG_PARAMETERS_SCRIPT_URL" ]; then
         TMP_PARAMS_OVERRIDE="/tmp/jenkins_params_override"
         rm -vf "$TMP_PARAMS_OVERRIDE"
 
         # Use tee to log content of override script for traceability.
-        curl --silent "$CONFIG_PARAMETERS_SCRIPT_URL" | tee "$TMP_PARAMS_OVERRIDE"
+        curl --silent "$TMP_CONFIG_PARAMETERS_SCRIPT_URL" | tee "$TMP_PARAMS_OVERRIDE"
 
         # Source script so it can alter ALL existing variables in the current context.
         . "$TMP_PARAMS_OVERRIDE"
@@ -177,27 +177,27 @@ handle_config_parameters_script_url() {
 
 # Allow full override of ALL configs before running test suite.
 #
-# USAGE: handle_config_override_script_url ["$CONFIG_OVERRIDE_SCRIPT_URL"]
+# USAGE: handle_config_override_script_url "$CONFIG_OVERRIDE_SCRIPT_URL"
 #
 handle_config_override_script_url() {
 
     if [ -n "$1" ]; then
-        CONFIG_OVERRIDE_SCRIPT_URL="$1"
+        TMP_CONFIG_OVERRIDE_SCRIPT_URL="$1"
     fi
 
-    if [ -n "$CONFIG_OVERRIDE_SCRIPT_URL" ]; then
+    if [ -n "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" ]; then
         TMP_CONF_OVERRIDE="/tmp/conf_override"
         rm -vf "$TMP_CONF_OVERRIDE"
 
 
-        if echo "$CONFIG_OVERRIDE_SCRIPT_URL" | grep -e ^http ; then
+        if echo "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" | grep -e ^http ; then
             # Use tee to log content of override script for traceability.
-            curl --silent "$CONFIG_OVERRIDE_SCRIPT_URL" | tee "$TMP_CONF_OVERRIDE"
+            curl --silent "$TMP_CONFIG_OVERRIDE_SCRIPT_URL" | tee "$TMP_CONF_OVERRIDE"
         else
             # Not starting with http, it's a local file.
             # Local file can be previously created by CONFIG_PARAMETERS_SCRIPT_URL.
             # See example in test-override/jenkins-params-raven-specific-nb.include.sh.
-            TMP_CONF_OVERRIDE="$CONFIG_OVERRIDE_SCRIPT_URL"
+            TMP_CONF_OVERRIDE="$TMP_CONFIG_OVERRIDE_SCRIPT_URL"
 
             # Log content of override script for traceability.
             cat "$TMP_CONF_OVERRIDE"

--- a/runtest
+++ b/runtest
@@ -50,8 +50,8 @@ export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 # See sample test-override/jenkins-params-default.include.sh.
 handle_config_override_script_url "$DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL"
 
-# 2nd default to override the first default.
-handle_config_override_script_url "$DEFAULT_2_CONFIG_OVERRIDE_SCRIPT_URL"
+# Override the default above, could be used by CI.
+handle_config_override_script_url "$CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL"
 
 # Allow full override of ALL configs before running test suite.
 handle_config_override_script_url "$CONFIG_OVERRIDE_SCRIPT_URL"

--- a/runtest
+++ b/runtest
@@ -47,6 +47,7 @@ export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
 # This default can be override by CONFIG_OVERRIDE_SCRIPT_URL and can be used in
 # DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL.
+# See sample test-override/jenkins-params-default.include.sh.
 handle_config_override_script_url "$DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL"
 
 # Allow full override of ALL configs before running test suite.

--- a/runtest
+++ b/runtest
@@ -92,7 +92,7 @@ for nb in $RESULTING_NOTEBOOKS; do
     fi
     cp "$nb" "$BUILDOUT_DIR/${filename}.ipynb"
 
-    if [ x"$SAVE_RESULTING_NOTEBOOK" = xtrue ]; then
+    if [ x"$SAVE_RESULTING_NOTEBOOK" = xtrue ] && enable_resulting_nb "${filename}" ; then
         # Timeout must not be more than 240s (4 mins). Default in Jenkinsfile.
         # Tutorial notebooks should be fast so user do not lose patience waiting
         # for them to run.  If more than 4 mins, in addition to simplifying the

--- a/runtest
+++ b/runtest
@@ -50,7 +50,7 @@ export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 handle_config_override_script_url "$DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL"
 
 # Allow full override of ALL configs before running test suite.
-handle_config_override_script_url
+handle_config_override_script_url "$CONFIG_OVERRIDE_SCRIPT_URL"
 
 # CONFIG_OVERRIDE_SCRIPT_URL can override NBVAL_SANITIZE_CFG_FILE.
 py.test --rootdir=. --nbval $NOTEBOOKS --nbval-sanitize-with "${NBVAL_SANITIZE_CFG_FILE:=notebooks/output-sanitize.cfg}" $PYTEST_EXTRA_OPTS

--- a/runtest
+++ b/runtest
@@ -50,6 +50,9 @@ export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 # See sample test-override/jenkins-params-default.include.sh.
 handle_config_override_script_url "$DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL"
 
+# 2nd default to override the first default.
+handle_config_override_script_url "$DEFAULT_2_CONFIG_OVERRIDE_SCRIPT_URL"
+
 # Allow full override of ALL configs before running test suite.
 handle_config_override_script_url "$CONFIG_OVERRIDE_SCRIPT_URL"
 

--- a/runtest
+++ b/runtest
@@ -96,7 +96,7 @@ for nb in $RESULTING_NOTEBOOKS; do
     fi
     cp "$nb" "$BUILDOUT_DIR/${filename}.ipynb"
 
-    if [ x"$SAVE_RESULTING_NOTEBOOK" = xtrue ] && enable_resulting_nb "${filename}" ; then
+    if [ x"$SAVE_RESULTING_NOTEBOOK" = xtrue ] && enable_resulting_nb "${nb}" ; then
         # Timeout must not be more than 240s (4 mins). Default in Jenkinsfile.
         # Tutorial notebooks should be fast so user do not lose patience waiting
         # for them to run.  If more than 4 mins, in addition to simplifying the

--- a/runtest
+++ b/runtest
@@ -45,30 +45,12 @@ fi
 # so tests still pass when user want to disable ssl cert verification
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
 
+# This default can be override by CONFIG_OVERRIDE_SCRIPT_URL and can be used in
+# DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL.
+handle_config_override_script_url "$DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL"
+
 # Allow full override of ALL configs before running test suite.
-if [ -n "$CONFIG_OVERRIDE_SCRIPT_URL" ]; then
-    TMP_CONF_OVERRIDE="/tmp/conf_override"
-    rm -vf "$TMP_CONF_OVERRIDE"
-
-
-    if echo "$CONFIG_OVERRIDE_SCRIPT_URL" | grep -e ^http ; then
-        # Use tee to log content of override script for traceability.
-        curl --silent "$CONFIG_OVERRIDE_SCRIPT_URL" | tee "$TMP_CONF_OVERRIDE"
-    else
-        # Not starting with http, it's a local file.
-        # Local file can be previously created by CONFIG_PARAMETERS_SCRIPT_URL.
-        # See example in test-override/jenkins-params-raven-specific-nb.include.sh.
-        TMP_CONF_OVERRIDE="$CONFIG_OVERRIDE_SCRIPT_URL"
-
-        # Log content of override script for traceability.
-        cat "$TMP_CONF_OVERRIDE"
-    fi
-
-    # Source script so it can alter ALL existing variables in the current context.
-    if [ -f "$TMP_CONF_OVERRIDE" ]; then
-        . "$TMP_CONF_OVERRIDE"
-    fi
-fi
+handle_config_override_script_url
 
 # CONFIG_OVERRIDE_SCRIPT_URL can override NBVAL_SANITIZE_CFG_FILE.
 py.test --rootdir=. --nbval $NOTEBOOKS --nbval-sanitize-with "${NBVAL_SANITIZE_CFG_FILE:=notebooks/output-sanitize.cfg}" $PYTEST_EXTRA_OPTS

--- a/runtest
+++ b/runtest
@@ -69,10 +69,15 @@ SAVE_RESULTING_NOTEBOOK="$(lowercase "$SAVE_RESULTING_NOTEBOOK")"
 # work-around as nbval can not save the result of the run
 # see https://github.com/computationalmodelling/nbval/issues/112
 
+RESULTING_NOTEBOOKS="$NOTEBOOKS"
+
 BUILDOUT_DIR="buildout"  # hardcode in Jenkinsfile, can not be override.
 
+# Pre-processing steps, override in CONFIG_OVERRIDE_SCRIPT_URL.
+pre_saving_resulting_nb
+
 mkdir -p "$BUILDOUT_DIR/"
-for nb in $NOTEBOOKS; do
+for nb in $RESULTING_NOTEBOOKS; do
     filename="$(choose_artifact_filename "$nb")"
     filename="$(echo "$filename" | sed "s/.ipynb$//")"  # remove .ipynb ext
     if [ -e "${BUILDOUT_DIR}/${filename}.ipynb" ]; then

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -34,6 +34,7 @@ enable_resulting_nb() {
     if [ x"$nb" = x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel" ] ||
        [ x"$nb" = x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators" ]; then
         # Blacklist those notebooks.
+        echo "Skipping \"$nb\"."
         return 1
     else
         # Enable all the rest.

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -22,10 +22,10 @@ echo '
 # Config override script to exclude default notebooks.
 
 # Add more -e for additional nbs to blacklist.
-NEW_NB_LIST="$(echo $NOTEBOOKS | sed \
-  -e "s@$RAVENPY_DIR/docs/notebooks/HydroShare_integration.ipynb@@" \
-  )"
-NOTEBOOKS="$NEW_NB_LIST"
+#NEW_NB_LIST="$(echo $NOTEBOOKS | sed \
+#  -e "s@$RAVENPY_DIR/docs/notebooks/HydroShare_integration.ipynb@@" \
+#  )"
+#NOTEBOOKS="$NEW_NB_LIST"
 
 
 # Select which notebooks to blacklist from generating output.

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -35,7 +35,7 @@ pre_saving_resulting_nb() {
     for nb in $RESULTING_NOTEBOOKS; do
         if [ x"$nb" != x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel.ipynb" ] &&
            [ x"$nb" != x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb" ]; then
-            NEW_RESULTING_NB="$nb"
+            NEW_RESULTING_NB="$NEW_RESULTING_NB $nb"
         fi
     done
     RESULTING_NOTEBOOKS="$NEW_RESULTING_NB"

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -21,12 +21,10 @@ echo '
 #!/bin/sh
 # Config override script to exclude default notebooks.
 
-NEW_NB_LIST=""
-for nb in $NOTEBOOKS; do
-    if [ x"$nb" != x"$RAVENPY_DIR/docs/notebooks/HydroShare_integration.ipynb" ]; then
-        NEW_NB_LIST="$NEW_NB_LIST $nb"
-    fi
-done
+# Add more -e for additional nbs to blacklist.
+NEW_NB_LIST="$(echo $NOTEBOOKS | sed \
+  -e "s@$RAVENPY_DIR/docs/notebooks/HydroShare_integration.ipynb@@" \
+  )"
 NOTEBOOKS="$NEW_NB_LIST"
 
 

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -30,11 +30,10 @@ NOTEBOOKS="$NEW_NB_LIST"
 
 # Select which notebooks to blacklist from generating output.
 enable_resulting_nb() {
-    nb="$1"
-    if [ x"$nb" = x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel" ] ||
-       [ x"$nb" = x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators" ]; then
+    if [ x"$1" = x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel.ipynb" ] ||
+       [ x"$1" = x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb" ]; then
         # Blacklist those notebooks.
-        echo "Skipping \"$nb\"."
+        echo "Skipping \"$1\"."
         return 1
     else
         # Enable all the rest.

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -29,15 +29,17 @@ for nb in $NOTEBOOKS; do
 done
 NOTEBOOKS="$NEW_NB_LIST"
 
-# Disable nb not required to generate output to speed up run time.
-pre_saving_resulting_nb() {
-    NEW_RESULTING_NB=""
-    for nb in $RESULTING_NOTEBOOKS; do
-        if [ x"$nb" != x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel.ipynb" ] &&
-           [ x"$nb" != x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb" ]; then
-            NEW_RESULTING_NB="$NEW_RESULTING_NB $nb"
-        fi
-    done
-    RESULTING_NOTEBOOKS="$NEW_RESULTING_NB"
+
+# Select which notebooks to blacklist from generating output.
+enable_resulting_nb() {
+    nb="$1"
+    if [ x"$nb" != x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel" ] ||
+       [ x"$nb" != x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators" ]; then
+        # Blacklist those notebooks.
+        return 1
+    else
+        # Enable all the rest.
+        return 0
+    fi
 }
 ' > "$DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL"

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Jenkins params override script to demonstrate excluding default
+# notebooks and on-the-fly DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL file creation.
+#
+# This script is intended for param DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL.
+
+# Scenario: we want to exclude some default notebooks that is known to not work
+# or we do not need to generate the output at the end.
+
+# Create DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL file on-the-fly to run the notebooks
+# from our external repo.
+
+DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL="/tmp/default-config-override.include.sh"
+
+# Populate the content of our DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL.
+echo '
+#!/bin/sh
+# Config override script to exclude default notebooks.
+
+NEW_NB_LIST=""
+for nb in $NOTEBOOKS; do
+    if [ x"$nb" != x"$RAVENPY_DIR/docs/notebooks/HydroShare_integration.ipynb" ]; then
+        NEW_NB_LIST="$NEW_NB_LIST $nb"
+    fi
+done
+NOTEBOOKS="$NEW_NB_LIST"
+
+# Disable nb not required to generate output to speed up run time.
+pre_saving_resulting_nb() {
+    NEW_RESULTING_NB=""
+    for nb in $RESULTING_NOTEBOOKS; do
+        if [ x"$nb" != x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel.ipynb" ] &&
+           [ x"$nb" != x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators.ipynb" ]; then
+            NEW_RESULTING_NB="$nb"
+        fi
+    done
+    RESULTING_NOTEBOOKS="$NEW_RESULTING_NB"
+}
+' > "$DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL"

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -13,6 +13,9 @@
 
 DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL="/tmp/default-config-override.include.sh"
 
+# Need to export so it is visible in 'runtest'.
+export DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL
+
 # Populate the content of our DEFAULT_CONFIG_OVERRIDE_SCRIPT_URL.
 echo '
 #!/bin/sh

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -31,8 +31,8 @@ NOTEBOOKS="$NEW_NB_LIST"
 # Select which notebooks to blacklist from generating output.
 enable_resulting_nb() {
     nb="$1"
-    if [ x"$nb" != x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel" ] ||
-       [ x"$nb" != x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators" ]; then
+    if [ x"$nb" = x"$PAVICS_SDI_DIR/docs/source/notebooks/FAQ_dask_parallel" ] ||
+       [ x"$nb" = x"$PAVICS_LANDING_DIR/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-3Climate-Indicators" ]; then
         # Blacklist those notebooks.
         return 1
     else

--- a/test-override/jenkins-params-external-repos.include.sh
+++ b/test-override/jenkins-params-external-repos.include.sh
@@ -60,16 +60,16 @@ NOTEBOOKS="$ROOK_DIR/notebooks/*.ipynb"
 # there will be
 # "buildout/pavics-sdi-master--regridding.ipynb" and
 # "buildout/pavics-sdi-master--regridding.output.ipynb"
-choose_artifact_filename() {
-    repo_branch="$(echo "$1" | sed "s@/.*@@")"
-    echo "${repo_branch}--$(basename "$1")"
-}
+#choose_artifact_filename() {
+#    repo_branch="$(echo "$1" | sed "s@/.*@@")"
+#    echo "${repo_branch}--$(basename "$1")"
+#}
 
 # Sample demo override post_runtest: create lots of artifacts for Jenkins to
 # archive to test how Jenkins will display its archive page.
-post_runtest() {
-    for i in $(seq --equal-width 500); do
-        echo "file${i}" > "${BUILDOUT_DIR}/file${i}.ipynb"
-    done
-}
+#post_runtest() {
+#    for i in $(seq --equal-width 500); do
+#        echo "file${i}" > "${BUILDOUT_DIR}/file${i}.ipynb"
+#    done
+#}
 ' > "$CONFIG_OVERRIDE_SCRIPT_URL"

--- a/test-override/jenkins-params-external-repos.include.sh
+++ b/test-override/jenkins-params-external-repos.include.sh
@@ -13,6 +13,8 @@ TEST_PAVICS_SDI_REPO="false"
 TEST_FINCH_REPO="false"
 TEST_PAVICS_LANDING_REPO="false"
 TEST_LOCAL_NOTEBOOKS="false"
+TEST_RAVEN_REPO="false"
+TEST_RAVENPY_REPO="false"
 
 # Set new external repo vars.  Need 'export' so CONFIG_OVERRIDE_SCRIPT_URL can see them.
 export ROOK_REPO="roocs/rook"

--- a/test-override/jenkins-params-external-repos.include.sh
+++ b/test-override/jenkins-params-external-repos.include.sh
@@ -28,6 +28,9 @@ PYTEST_EXTRA_OPTS="$PYTEST_EXTRA_OPTS --nbval-lax"
 
 CONFIG_OVERRIDE_SCRIPT_URL="/tmp/custom-repos.include.sh"
 
+# export so it is visible by 'runtest'.
+export CONFIG_OVERRIDE_SCRIPT_URL
+
 # Populate the content of our CONFIG_OVERRIDE_SCRIPT_URL.
 echo '
 #!/bin/sh

--- a/test-override/jenkins-params-external-repos.include.sh
+++ b/test-override/jenkins-params-external-repos.include.sh
@@ -18,7 +18,7 @@ TEST_RAVENPY_REPO="false"
 
 # Set new external repo vars.  Need 'export' so CONFIG_OVERRIDE_SCRIPT_URL can see them.
 export ROOK_REPO="roocs/rook"
-export ROOK_BRANCH="master"
+export ROOK_BRANCH="main"
 
 # Hijack PAVICS_SDI fields for interractive build request ROOK override.
 [ x"$PAVICS_SDI_REPO" != x"Ouranosinc/pavics-sdi" ] && ROOK_REPO="$PAVICS_SDI_REPO"

--- a/test-override/jenkins-params-external-repos.include.sh
+++ b/test-override/jenkins-params-external-repos.include.sh
@@ -20,6 +20,10 @@ TEST_RAVENPY_REPO="false"
 export ROOK_REPO="roocs/rook"
 export ROOK_BRANCH="master"
 
+# Hijack PAVICS_SDI fields for interractive build request ROOK override.
+[ x"$PAVICS_SDI_REPO" != x"Ouranosinc/pavics-sdi" ] && ROOK_REPO="$PAVICS_SDI_REPO"
+[ x"$PAVICS_SDI_BRANCH" != x"master" ] && ROOK_BRANCH="$PAVICS_SDI_BRANCH"
+
 # Not checking for expected output, just checking whether the code can run without errors.
 PYTEST_EXTRA_OPTS="$PYTEST_EXTRA_OPTS --nbval-lax"
 

--- a/test-override/jenkins-params-geoserver-nb-only.include.sh
+++ b/test-override/jenkins-params-geoserver-nb-only.include.sh
@@ -21,6 +21,9 @@ export TEST_NO_USE_PROD_DATA=1
 # GeoServer only.
 CONFIG_OVERRIDE_SCRIPT_URL="https://raw.githubusercontent.com/Ouranosinc/PAVICS-e2e-workflow-tests/master/test-override/geoserver-nb-only.include.sh"
 
+# export so it is visible by 'runtest'.
+export CONFIG_OVERRIDE_SCRIPT_URL
+
 # Set different test branch if required.
 #PAVICS_SDI_BRANCH=""
 #FINCH_BRANCH=""

--- a/test-override/jenkins-params-raven-specific-nb.include.sh
+++ b/test-override/jenkins-params-raven-specific-nb.include.sh
@@ -20,6 +20,9 @@ cat test-override/jenkins-params-raven-nb-only.include.sh
 
 CONFIG_OVERRIDE_SCRIPT_URL="/tmp/specific-raven-nb.include.sh"
 
+# export so it is visible by 'runtest'.
+export CONFIG_OVERRIDE_SCRIPT_URL
+
 echo '
 #!/bin/sh
 # Sample config override script to only run 2 specific raven notebooks.

--- a/testall
+++ b/testall
@@ -13,6 +13,22 @@ if [ x"${TEST_ALL_SKIP_CLEANUP}" != x"true" ]; then
   git clean -fdx
 fi
 
+
+# Allow full override of ALL Jenkins params before running test suite.
+# Same as CONFIG_PARAMETERS_SCRIPT_URL below but this allow to specify default
+# behavior that CONFIG_PARAMETERS_SCRIPT_URL below can override.
+if [ -n "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL" ]; then
+    DEFAULT_TMP_PARAMS_OVERRIDE="/tmp/default_jenkins_params_override"
+    rm -vf "$DEFAULT_TMP_PARAMS_OVERRIDE"
+
+    # Use tee to log content of override script for traceability.
+    curl --silent "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL" | tee "$DEFAULT_TMP_PARAMS_OVERRIDE"
+
+    # Source script so it can alter ALL existing variables in the current context.
+    . "$DEFAULT_TMP_PARAMS_OVERRIDE"
+fi
+
+
 # Allow full override of ALL Jenkins params before running test suite.
 # Intended to override all params in Jenkinsfile.
 #

--- a/testall
+++ b/testall
@@ -26,7 +26,7 @@ handle_config_parameters_script_url "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL"
 
 
 # Allow full override of ALL Jenkins params before running test suite.
-handle_config_parameters_script_url
+handle_config_parameters_script_url "$CONFIG_PARAMETERS_SCRIPT_URL"
 
 
 # download all additional repos containing extra notebooks to test

--- a/testall
+++ b/testall
@@ -22,6 +22,8 @@ fi
 # The CONFIG_PARAMETERS_SCRIPT_URL is a Jenkins parameter so it is like the
 # interractive version, while this DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL can be
 # viewed as the unattended version.
+#
+# See sample test-override/jenkins-params-default.include.sh.
 handle_config_parameters_script_url "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL"
 
 

--- a/testall
+++ b/testall
@@ -15,48 +15,19 @@ fi
 
 
 # Allow full override of ALL Jenkins params before running test suite.
+#
 # Same as CONFIG_PARAMETERS_SCRIPT_URL below but this allow to specify default
 # behavior that CONFIG_PARAMETERS_SCRIPT_URL below can override.
-if [ -n "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL" ]; then
-    DEFAULT_TMP_PARAMS_OVERRIDE="/tmp/default_jenkins_params_override"
-    rm -vf "$DEFAULT_TMP_PARAMS_OVERRIDE"
-
-    # Use tee to log content of override script for traceability.
-    curl --silent "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL" | tee "$DEFAULT_TMP_PARAMS_OVERRIDE"
-
-    # Source script so it can alter ALL existing variables in the current context.
-    . "$DEFAULT_TMP_PARAMS_OVERRIDE"
-fi
+#
+# The CONFIG_PARAMETERS_SCRIPT_URL is a Jenkins parameter so it is like the
+# interractive version, while this DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL can be
+# viewed as the unattended version.
+handle_config_parameters_script_url "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL"
 
 
 # Allow full override of ALL Jenkins params before running test suite.
-# Intended to override all params in Jenkinsfile.
-#
-# This `CONFIG_PARAMETERS_SCRIPT_URL` is different than the
-# `CONFIG_OVERRIDE_SCRIPT_URL` in that it overrides all the
-# Jenkins params much sooner so all regular processing can take place.
-#
-# When the regular processing are not enough and we need additional
-# customizations, then we use the other `CONFIG_OVERRIDE_SCRIPT_URL`.
-#
-# The two override scripts complement each other by hooking into the
-# process at different moment in time, and together they allow full
-# complete override of the various options for the test run.
-#
-# Furthermore, CONFIG_OVERRIDE_SCRIPT_URL can also be a local file that is
-# created on the fly by CONFIG_PARAMETERS_SCRIPT_URL.  So in the end, only
-# CONFIG_PARAMETERS_SCRIPT_URL is needed for a full complete override.
-# See example in test-override/jenkins-params-raven-specific-nb.include.sh.
-if [ -n "$CONFIG_PARAMETERS_SCRIPT_URL" ]; then
-    TMP_PARAMS_OVERRIDE="/tmp/jenkins_params_override"
-    rm -vf "$TMP_PARAMS_OVERRIDE"
+handle_config_parameters_script_url
 
-    # Use tee to log content of override script for traceability.
-    curl --silent "$CONFIG_PARAMETERS_SCRIPT_URL" | tee "$TMP_PARAMS_OVERRIDE"
-
-    # Source script so it can alter ALL existing variables in the current context.
-    . "$TMP_PARAMS_OVERRIDE"
-fi
 
 # download all additional repos containing extra notebooks to test
 DOWNLOAD_ALL_DEFAULT_REPOS=false

--- a/testall
+++ b/testall
@@ -26,6 +26,8 @@ fi
 # See sample test-override/jenkins-params-default.include.sh.
 handle_config_parameters_script_url "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL"
 
+# 2nd default to override the first default.
+handle_config_parameters_script_url "$DEFAULT_2_CONFIG_PARAMETERS_SCRIPT_URL"
 
 # Allow full override of ALL Jenkins params before running test suite.
 handle_config_parameters_script_url "$CONFIG_PARAMETERS_SCRIPT_URL"

--- a/testall
+++ b/testall
@@ -25,13 +25,13 @@ fi
 #
 # See sample test-override/jenkins-params-default.include.sh.
 #
-# Utilisation example: https://github.com/Ouranosinc/jenkins-config/blob/f2de2241ee4fd6c516cee67d29600e313d4b4f7c/jcasc/global_env_var.yaml#L11-L12
+# CI usage sample: https://github.com/Ouranosinc/jenkins-config/blob/f2de2241ee4fd6c516cee67d29600e313d4b4f7c/jcasc/global_env_var.yaml#L11-L12
 # See PR https://github.com/Ouranosinc/jenkins-config/pull/17.
 handle_config_parameters_script_url "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL"
 
 # Override the default above, could be used by CI.
 #
-# Utilisation example: https://github.com/Ouranosinc/jenkins-config/blob/f2de2241ee4fd6c516cee67d29600e313d4b4f7c/jcasc_ouranos/staging_jobs.yaml#L87
+# CI usage sample: https://github.com/Ouranosinc/jenkins-config/blob/f2de2241ee4fd6c516cee67d29600e313d4b4f7c/jcasc_ouranos/staging_jobs.yaml#L87
 # See PR https://github.com/Ouranosinc/jenkins-config/pull/17.
 handle_config_parameters_script_url "$CI_OVERRIDE_CONFIG_PARAMETERS_SCRIPT_URL"
 

--- a/testall
+++ b/testall
@@ -24,10 +24,16 @@ fi
 # viewed as the unattended version.
 #
 # See sample test-override/jenkins-params-default.include.sh.
+#
+# Utilisation example: https://github.com/Ouranosinc/jenkins-config/blob/f2de2241ee4fd6c516cee67d29600e313d4b4f7c/jcasc/global_env_var.yaml#L11-L12
+# See PR https://github.com/Ouranosinc/jenkins-config/pull/17.
 handle_config_parameters_script_url "$DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL"
 
-# 2nd default to override the first default.
-handle_config_parameters_script_url "$DEFAULT_2_CONFIG_PARAMETERS_SCRIPT_URL"
+# Override the default above, could be used by CI.
+#
+# Utilisation example: https://github.com/Ouranosinc/jenkins-config/blob/f2de2241ee4fd6c516cee67d29600e313d4b4f7c/jcasc_ouranos/staging_jobs.yaml#L87
+# See PR https://github.com/Ouranosinc/jenkins-config/pull/17.
+handle_config_parameters_script_url "$CI_OVERRIDE_CONFIG_PARAMETERS_SCRIPT_URL"
 
 # Allow full override of ALL Jenkins params before running test suite.
 handle_config_parameters_script_url "$CONFIG_PARAMETERS_SCRIPT_URL"


### PR DESCRIPTION
To be used together with https://github.com/Ouranosinc/jenkins-config/pull/17.

If Jenkins `env.local` contains `export DEFAULT_CONFIG_PARAMETERS_SCRIPT_URL="https://raw.githubusercontent.com/Ouranosinc/PAVICS-e2e-workflow-tests/refs/heads/master/test-override/jenkins-params-default.include.sh"` notebooks that are known to have problems will be skipped so that Jenkins do not fail for known reasons.

This is related to https://github.com/bird-house/birdhouse-deploy/issues/496.  If raven notebooks are enabled by default, then we need to blacklist one of them because that one never passed, see `test-override/jenkins-params-default.include.sh` (the file that Jenkins will be pointed to).  The raven notebook is finally disabled by this PR https://github.com/CSHS-CWRA/RavenPy/pull/460.

In this same effort, we also add the ability to blacklist notebooks only at the "generating output.ipynb" stage, but not in "pytest stage".  The reason is that those notebooks have some cells that are disabled during the "pytest stage" because they take too long so then there are no reason to generate the output because 1) it will timeout anyways, 2) the output won't match since some cells are disabled during "pytest stage".

@fmigneault 
CRIM should simply point to our `https://raw.githubusercontent.com/Ouranosinc/PAVICS-e2e-workflow-tests/refs/heads/master/test-override/jenkins-params-default.include.sh` file so we will be responsible for keeping up-to-date this list of known failures to prevent breaking CRIM pipeline.

