### PR TITLE
jenkins: enable raven and ravenpy nbs by default in nightly builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,13 +71,13 @@ Requires 'weaver' component to be active on the target 'PAVICS_HOST' server
                description: 'PAVICS_LANDING_REPO branch to test against.', trim: true)
         string(name: 'PAVICS_LANDING_REPO', defaultValue: 'Ouranosinc/PAVICS-landing',
                description: 'https://github.com/Ouranosinc/PAVICS-landing repo or fork to test against.', trim: true)
-        booleanParam(name: 'TEST_RAVEN_REPO', defaultValue: false,
+        booleanParam(name: 'TEST_RAVEN_REPO', defaultValue: true,
                      description: 'Check the box to test raven repo.')
         string(name: 'RAVEN_BRANCH', defaultValue: 'main',
                description: 'RAVEN_REPO branch to test against.', trim: true)
         string(name: 'RAVEN_REPO', defaultValue: 'Ouranosinc/raven',
                description: 'https://github.com/Ouranosinc/raven repo or fork to test against.', trim: true)
-        booleanParam(name: 'TEST_RAVENPY_REPO', defaultValue: false,
+        booleanParam(name: 'TEST_RAVENPY_REPO', defaultValue: true,
                      description: 'Check the box to test RavenPy repo.')
         string(name: 'RAVENPY_BRANCH', defaultValue: 'master',
                description: 'RAVENPY_REPO branch to test against.', trim: true)

--- a/default_build_params
+++ b/default_build_params
@@ -64,7 +64,7 @@ else
 fi
 
 if [ -z "$TEST_RAVEN_REPO" ]; then
-    TEST_RAVEN_REPO=false
+    TEST_RAVEN_REPO=true
     echo "TEST_RAVEN_REPO not set, default to '$TEST_RAVEN_REPO'"
 else
     echo "TEST_RAVEN_REPO has been set to '$TEST_RAVEN_REPO'"
@@ -85,7 +85,7 @@ else
 fi
 
 if [ -z "$TEST_RAVENPY_REPO" ]; then
-    TEST_RAVENPY_REPO=false
+    TEST_RAVENPY_REPO=true
     echo "TEST_RAVENPY_REPO not set, default to '$TEST_RAVENPY_REPO'"
 else
     echo "TEST_RAVENPY_REPO has been set to '$TEST_RAVENPY_REPO'"

--- a/test-override/jenkins-params-raven-nb-only.include.sh
+++ b/test-override/jenkins-params-raven-nb-only.include.sh
@@ -15,7 +15,7 @@ TEST_RAVENPY_REPO="true"
 
 # Raven nbs outputs are not fully up-to-date or regexed escaped properly like
 # the other default nbs so need --nbval-lax for the moment.
-PYTEST_EXTRA_OPTS="$PYTEST_EXTRA_OPTS --nbval-lax"
+#PYTEST_EXTRA_OPTS="$PYTEST_EXTRA_OPTS --nbval-lax"
 
 # Set different test branch if required.
 #RAVEN_BRANCH=""


### PR DESCRIPTION
All raven and ravenpy notebooks are now passing without the need for `--nbval-lax`.

Before, with the need of `--nbval-lax`, we could not have raven nbs running along-side of other notebooks that do not need `--nbval-lax`.

`--nbval-lax` option is for the entire run, it could not be specified per notebook.

Fixes https://github.com/bird-house/birdhouse-deploy/issues/496
