### PR TITLE
Additional Jenkins overrides for special case pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,9 +159,9 @@ Note this is another run, will double the time and no guaranty to have same erro
     options {
         ansiColor('xterm')
         timestamps()
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         // trying to keep 3 months worth of history
         // assuming manual build requests are done on a separated job
-        buildDiscarder(logRotator(numToKeepStr: '100'))
+        buildDiscarder(logRotator(numToKeepStr: '90'))
     }
 }

--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -121,6 +121,12 @@ replace: /tmpRANDOM.png
 regex: /tmp[a-zA-Z0-9_]{8}/
 replace: /tmpRANDOM/
 
+[NamedTemporaryFile-default-prefix]
+# regridding.ipynb: NamedTemporaryFile(delete=False, suffix=".nc")
+# Weight filename:            /tmp/tmpkff8m7mo.nc
+regex: /tmp/tmp[a-zA-Z0-9_]{8}\.
+replace: /tmp/tmpRANDOM.
+
 [ipykernel-temp-dir]
 # - /tmp/ipykernel_1380/857013960.py:1: FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead
 # ?                 ^^^

--- a/test-override/jenkins-params-enable-nbval-skip.include.sh
+++ b/test-override/jenkins-params-enable-nbval-skip.include.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Jenkins params override script to demonstrate pre processing
+# and on-the-fly CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL file creation.
+#
+# This script is intended for param CI_OVERRIDE_CONFIG_PARAMETERS_SCRIPT_URL.
+
+# Scenario: we want to actually run notebook cells marked with NBVAL_SKIP.
+
+# Create CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL file on-the-fly to perform pre
+# processing to replace NBVAL_SKIP with NBVAL_IGNORE_OUTPUT.
+
+CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL="/tmp/ci-override-config-override.include.sh"
+
+# Need to export so it is visible in 'runtest'.
+export CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL
+
+# Populate the content of our CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL.
+echo '
+#!/bin/sh
+# Config override script to perform pre and post processing.
+
+sed -i "s/NBVAL_SKIP/NBVAL_IGNORE_OUTPUT/g" $NOTEBOOKS
+' > "$CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL"

--- a/test-override/jenkins-params-external-repos.include.sh
+++ b/test-override/jenkins-params-external-repos.include.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
 # Sample Jenkins params override script to demonstrate running new notebooks
-# from an external repo and on-the-fly CONFIG_OVERRIDE_SCRIPT_URL file creation.
+# from an external repo and on-the-fly CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL file creation.
 #
-# This script is intended for param CONFIG_PARAMETERS_SCRIPT_URL.
+# This script is intended for param CI_OVERRIDE_CONFIG_PARAMETERS_SCRIPT_URL.
 
 # Scenario: we want to run notebooks from an external repo, unknown to current Jenkins config.
 # https://github.com/roocs/rook/tree/master/notebooks/*.ipynb
@@ -16,7 +16,7 @@ TEST_LOCAL_NOTEBOOKS="false"
 TEST_RAVEN_REPO="false"
 TEST_RAVENPY_REPO="false"
 
-# Set new external repo vars.  Need 'export' so CONFIG_OVERRIDE_SCRIPT_URL can see them.
+# Set new external repo vars.  Need 'export' so CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL can see them.
 export ROOK_REPO="roocs/rook"
 export ROOK_BRANCH="main"
 
@@ -27,15 +27,15 @@ export ROOK_BRANCH="main"
 # Not checking for expected output, just checking whether the code can run without errors.
 PYTEST_EXTRA_OPTS="$PYTEST_EXTRA_OPTS --nbval-lax"
 
-# Create CONFIG_OVERRIDE_SCRIPT_URL file on-the-fly to run the notebooks from
+# Create CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL file on-the-fly to run the notebooks from
 # our external repo.
 
-CONFIG_OVERRIDE_SCRIPT_URL="/tmp/custom-repos.include.sh"
+CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL="/tmp/ci-override-custom-repos.include.sh"
 
 # export so it is visible by 'runtest'.
-export CONFIG_OVERRIDE_SCRIPT_URL
+export CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL
 
-# Populate the content of our CONFIG_OVERRIDE_SCRIPT_URL.
+# Populate the content of our CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL.
 echo '
 #!/bin/sh
 # Sample config override script to run new notebooks from new external repo.
@@ -72,4 +72,4 @@ NOTEBOOKS="$ROOK_DIR/notebooks/*.ipynb"
 #        echo "file${i}" > "${BUILDOUT_DIR}/file${i}.ipynb"
 #    done
 #}
-' > "$CONFIG_OVERRIDE_SCRIPT_URL"
+' > "$CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL"

--- a/test-override/jenkins-params-readonly-checkout.include.sh
+++ b/test-override/jenkins-params-readonly-checkout.include.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Jenkins params override script to demonstrate pre and post processing
+# and on-the-fly CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL file creation.
+#
+# This script is intended for param CI_OVERRIDE_CONFIG_PARAMETERS_SCRIPT_URL.
+
+# Scenario: we want to test notebooks when the checkout is fully read-only.
+
+# Create CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL file on-the-fly to perform pre
+# and post processing to turn on and off read-only checkout.
+
+CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL="/tmp/ci-override-config-override.include.sh"
+
+# Need to export so it is visible in 'runtest'.
+export CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL
+
+# Populate the content of our CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL.
+echo '
+#!/bin/sh
+# Config override script to perform pre and post processing.
+
+# For artifact archiving steps, have to do this in advance when we still have write-access
+# because next step we will make everything read-only.
+mkdir buildout
+
+# Read-only in checkout to emulate read-only tutorial-notebooks/ dir on PAVICS.
+chmod a-w -R .
+
+# So we do not break the artifact archiving step.
+chmod ug+w buildout
+
+post_runtest() {
+  # Restore write-access so subsequent build request "checkout cleanup" step works.
+  chmod ug+w -R .
+}
+' > "$CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL"


### PR DESCRIPTION
* Double timeout and slight decrease of build retention because RavenPy notebooks are enabled by default so it takes longer to run and artifacts size will be bigger.

* Add more override so we can create custom pipeline for special cases, see https://github.com/Ouranosinc/jenkins-config/pull/18