### PR TITLE
test-override: update default blacklist mechanism to be simpler

### DIFF
--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -22,10 +22,11 @@ echo '
 # Config override script to exclude default notebooks.
 
 # Add more -e for additional nbs to blacklist.
-#NEW_NB_LIST="$(echo $NOTEBOOKS | sed \
-#  -e "s@$RAVENPY_DIR/docs/notebooks/HydroShare_integration.ipynb@@" \
-#  )"
-#NOTEBOOKS="$NEW_NB_LIST"
+# esgf-dap: https://github.com/Ouranosinc/pavics-sdi/issues/353
+NEW_NB_LIST="$(echo $NOTEBOOKS | sed \
+  -e "s@$PAVICS_SDI_DIR/docs/source/notebooks/esgf-dap.ipynb@@" \
+  )"
+NOTEBOOKS="$NEW_NB_LIST"
 
 
 # Select which notebooks to blacklist from generating output.

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -21,12 +21,18 @@ echo '
 #!/bin/sh
 # Config override script to exclude default notebooks.
 
-# Add more -e for additional nbs to blacklist.
 # esgf-dap: https://github.com/Ouranosinc/pavics-sdi/issues/353
-NEW_NB_LIST="$(echo $NOTEBOOKS | sed \
-  -e "s@$PAVICS_SDI_DIR/docs/source/notebooks/esgf-dap.ipynb@@" \
-  )"
-NOTEBOOKS="$NEW_NB_LIST"
+BLACKLIST_NOTEBOOKS="$PAVICS_SDI_DIR/docs/source/notebooks/esgf-dap.ipynb"
+
+if [ -n "$BLACKLIST_NOTEBOOKS" ]; then
+    sed_args=""
+    for bad_nb in $BLACKLIST_NOTEBOOKS; do
+        sed_args="$sed_args -e s@$bad_nb@@"
+    done
+
+    NEW_NB_LIST="$(echo $NOTEBOOKS | sed $sed_args)"
+    NOTEBOOKS="$NEW_NB_LIST"
+fi
 
 
 # Select which notebooks to blacklist from generating output.

--- a/test-override/jenkins-params-default.include.sh
+++ b/test-override/jenkins-params-default.include.sh
@@ -21,8 +21,8 @@ echo '
 #!/bin/sh
 # Config override script to exclude default notebooks.
 
-# esgf-dap: https://github.com/Ouranosinc/pavics-sdi/issues/353
-BLACKLIST_NOTEBOOKS="$PAVICS_SDI_DIR/docs/source/notebooks/esgf-dap.ipynb"
+#BLACKLIST_NOTEBOOKS="$PAVICS_SDI_DIR/docs/source/notebooks/esgf-dap.ipynb"
+BLACKLIST_NOTEBOOKS=""
 
 if [ -n "$BLACKLIST_NOTEBOOKS" ]; then
     sed_args=""


### PR DESCRIPTION
This blacklist can be lifted once https://github.com/Ouranosinc/pavics-sdi/issues/353 is fixed.

Edit: We do not need this blacklist anymore.  The notebook restarted working, see https://github.com/Ouranosinc/pavics-sdi/pull/355.  We can still merge this PR for a nicer blacklisting mechanism.