### PR TITLE
Drop PyPI packages from Jupter environment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,65 +1,60 @@
 # Overview
 
-Please include a summary of the changes and which issues is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+<!-- Please include a summary of the changes and which issues is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
-This PR fixes [issue id](url)
+This PR fixes [issue id](URL_HERE) by [explain how it fixes the issue]. It also includes [any other relevant changes].
 
 <!-- NOTE: Remember to tag 'release-py###-######' on the commit of this merge. -->
-
 
 ## Changes
 
 - Adds...
 - Jupyter env changes:
-  - Change 1 (related PR url)
-  - Change 2 (related PR url)
+  - Change 1 
+    - _Related PR URL_
+  - Change 2 
+    - _Related PR URL_
   - Relevant changes (alphabetical order):
 ```diff
 <   - somelib=0.8.1=pyh6c4a22f_1
 >   - somelib=0.8.4=pyh1a96a4e_0
 
 (...)
-
 ```
 
+## Testing Checklist
 
-## Test
-
-- Deployed as "beta" image in production for bokeh visualization performance regression testing.
-- Manual test notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance and it looks fine.
-- Jenkins build:
-  - Default notebooks https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/NEW-release-py###-######/docker/saved_buildout/jenkins-buildlogs-default.txt
-  - Raven notebooks https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/NEW-release-py###-######/docker/saved_buildout/jenkins-buildlogs-raven.txt
-
+- [ ] Deployed as "beta" image in production for bokeh visualization performance regression testing.
+- [ ] Manually tested notebook https://github.com/Ouranosinc/PAVICS-landing/blob/master/content/notebooks/climate_indicators/PAVICStutorial_ClimateDataAnalysis-5Visualization.ipynb for bokeh visualization performance.
+- [ ] Committed the Jenkins build log to this Pull Request: https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/NEW-release-py###-######/docker/saved_buildout/jenkins-buildlogs-default.txt
 
 ## Related Issue / Discussion
 
 - Matching notebook fixes:
-  - Pavics-sdi: PR url
-  - Finch: PR url
-  - PAVICS-landing: PR url
-  - RavenPy: PR url
+  - pavics-sdi: _PR URL_
+  - finch: _PR URL_
+  - PAVICS-landing: _PR URL_
+  - RavenPy: _PR URL_
   - (...)
 
-- Deployment to PAVICS: PR url
+- Deployment to PAVICS: _PR URL_
 
-- Jenkins-config changes for new notebooks: PR url
+- Jenkins-config changes for new notebooks: _PR URL_
 
 - Other issues found while working on this one
-  - Issue 1 URL
-  - Issue 2 URL
+  - _Issue 1 URL_
+  - _Issue 2 URL_
   - (...)
 
-- Previous release: PR url
-
+- Previous release: _PR URL_
 
 ## Additional Information
 
-Full diff conda env export:
+Full diff of the conda env export:
 https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/compare/PREVIOUS-release-py###-######...NEW-release-py###-######
 
 Full new conda env export:
 https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/NEW-release-py###-######/docker/saved_buildout/conda-env-export.yml
 
-DockerHub build log
+DockerHub build log:
 https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/NEW-release-py###-######/docker/saved_buildout/docker-buildlogs.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ COPY environment.yml /environment.yml
 # DEBUG conda.common._logic:_run_sat(607): Invoking SAT with clause count: 2500273
 #
 RUN umask 0000 && \
-    mamba create --name birdy --channel conda-forge ravenpy xclim xscen xsdba python=3.11 --yes && \
+    mamba create --name birdy --channel conda-forge python=3.11 clisops figanos ravenpy xclim xscen xsdba --yes && \
     (conda env export --name birdy 2>&1 | tee /conda-env-export-phase1.yml) && \
     (du -sh /opt/conda 2>&1 | tee /conda-envs-size-phase1.txt) && \
     mamba env update --name birdy --file /environment.yml && \

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -9,12 +9,12 @@ USER root
 
 # Use 'update' for existing and 'install' for new package.
 # Keep same channel ordering to not revert anything.
-RUN umask 0000 && \
-    conda config --prepend channels nodefaults || true && \
-    conda config --remove channels defaults || true && \
-    pip uninstall -y hsclient && \
-    mamba install --force-reinstall -c conda-forge -c cdat -c bokeh -c fortiers ravenpy==0.18.1 sparse==0.15.5 && \
-    mamba clean --all --yes
+# RUN umask 0000 && \
+#     conda config --prepend channels nodefaults || true && \
+#     conda config --remove channels defaults || true && \
+#     pip uninstall -y hsclient && \
+#     mamba install --force-reinstall -c conda-forge -c cdat -c bokeh -c fortiers ravenpy==0.18.1 sparse==0.15.5 && \
+#     mamba clean --all --yes
 
 # RUN umask 0000 && \
 #     pip uninstall -y ravenpy birdhouse-birdy && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,8 @@
 # pavics/workflow-tests
 Image to run workflow tests from jupyter notebooks.
 
-This image can also be launched by
-[`jupyterhub/jupyterhub`](https://hub.docker.com/r/jupyterhub/jupyterhub) as a
-notebook image, similar to the public
-[`jupyter/scipy-notebook`](https://hub.docker.com/r/jupyter/scipy-notebook)
-notebook image.
+This image can also be launched by [`jupyterhub/jupyterhub`](https://hub.docker.com/r/jupyterhub/jupyterhub) as a notebook image, similar to the public [`jupyter/scipy-notebook`](https://hub.docker.com/r/jupyter/scipy-notebook)notebook image.
 
-See
-[`launchcontainer`](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/master/launchcontainer)
-script for how to use this image.
+See [`launchcontainer`](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/master/launchcontainer) script for how to use this image.
 
-See
-[README.md](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/master/README.md)
-for additional infos.
+See [README.md](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/blob/master/README.md) for additional infos.

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -20,6 +20,8 @@ dependencies:
 
   # clisops: Data reduction operations on xarray climate data
   - clisops >= 0.16.1
+  # figanos: Outils pour produire des graphiques informatifs sur les impacts des changements climatiques.
+  - figanos >= 0.5.0
   # RavenPy: A Python wrapper for configuring and running the hydrologic modelling framework Raven.
   - ravenpy >= 0.18.1
   # xclim: Climate indices computation package based on Xarray.
@@ -68,6 +70,8 @@ dependencies:
   # - xarray  # managed by core libraries
   # xesmf: Universal Regridder for Geospatial Data
   - xesmf >= 0.8.9
+  # xncml: Tools for manipulating and opening NCML (NetCDF Markup) files with/for xarray
+  - xncml >= 0.5.0
   # zarr: Python implementation of Zarr, a format for chunked, compressed, N-dimensional arrays
   # - zarr  # managed by core libraries
 
@@ -305,17 +309,3 @@ dependencies:
 
   # PIP PACKAGE SUPPORT
   - pip # Needed for pip packages
-  - xmltodict # Needed for xncml
-  - xsdata # Needed for xncml
-
-  # PIP PACKAGES
-  - pip:
-    # figanos: Outils pour produire des graphiques informatifs sur les impacts des changements climatiques.
-    # https://pypi.org/project/figanos/
-    - figanos >= 0.4.0
-    # xncml: Tools for manipulating and opening NCML (NetCDF Markup) files with/for xarray
-    # https://pypi.org/project/xncml/
-    - xncml
-    # ipython_blocking: block execution of 'run_all_cells' until user input finished
-    # https://github.com/kafonek/ipython_blocking
-    - ipython_blocking

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   # xsdba direct dependencies: https://github.com/conda-forge/xsdba-feedstock/blob/main/recipe/meta.yaml
 
   # Pin latest clisops, figanos, ravenpy, xclim, xhydro, xscen, and xsdba to avoid undesired downgrades.
+  # Installation proceeds in two phases in the Dockerfile in order to avoid memory usage issues.
   # Mamba is quicker to solve dependencies than conda, but it is less precise so accidental downgrades can happen.
 
   ## CORE LIBRARIES

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -7,13 +7,14 @@ channels:
   - fortiers  # for fstd2nc
 dependencies:
   # clisops direct dependencies: https://github.com/conda-forge/clisops-feedstock/blob/master/recipe/meta.yaml
+  # figanos direct dependencies: https://github.com/conda-forge/figanos-feedstock/blob/master/recipe/meta.yaml
   # ravenpy direct dependencies: https://github.com/conda-forge/ravenpy-feedstock/blob/master/recipe/meta.yaml
   # xclim direct dependencies: https://github.com/conda-forge/xclim-feedstock/blob/master/recipe/meta.yaml
   # xhydro direct dependencies: https://github.com/conda-forge/xhydro-feedstock/blob/main/recipe/meta.yaml
   # xscen direct dependencies: https://github.com/conda-forge/xscen-feedstock/blob/main/recipe/meta.yaml
   # xsdba direct dependencies: https://github.com/conda-forge/xsdba-feedstock/blob/main/recipe/meta.yaml
 
-  # Pin latest clisops, ravenpy, xclim, xhydro, xscen, and xsdba to avoid downgrading during the second installation phase.
+  # Pin latest clisops, figanos, ravenpy, xclim, xhydro, xscen, and xsdba to avoid undesired downgrades.
   # Mamba is quicker to solve dependencies than conda, but it is less precise so accidental downgrades can happen.
 
   ## CORE LIBRARIES


### PR DESCRIPTION
# Overview

This PR removes the remaining `PyPI`-provided packages from the build environment, allowing us to solely leverage `conda-forge` when generating our PAVICS kernels.

`figanos` was previously pinning `numpy` below v2.0, causing the environment to reinstall an older, `PyPI`-provided `numpy`. This is no longer the case (with `figanos>=0.5.0`).

## Changes

- Removed `ipython_blocking` (obselete/unused)
- Replaced `figanos` (v0.4.0) and `xncml` (v0.4.0) `PyPI`-provided packages with their `conda-forge` package equivalents (v0.5.0 for both). 
- Updated the Pull Request templates to remove obsolete entries and clarify a few steps.

