### PR TITLE
Add a docker building workflow

### DIFF
--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -1,0 +1,43 @@
+name: Docker-based Testing Suite
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: "docker/Dockerfile"
+          tags: workflow-tests:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: false
+      - name: Run Docker image
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3.0.0
+        with:
+          image: workflow-tests:latest
+          run: |
+            set -e
+            echo "Running tests in Docker container"
+            # Run the test script inside the Docker container
+            conda list


### PR DESCRIPTION
# Overview

This PR adds a workflow for testing whether the docker image can be easily built.

## Changes

- Adds `docker-testing.yml` workflow for building the docker image and running smoke tests.

## Related Issue / Discussion

This workflow could be leverage to generate the docker images from GitHub Workflows, rather than relying on docker-build services on Dockerhub.

## Additional Information

https://github.com/docker/setup-buildx-action
https://github.com/docker/build-push-action

and possibly, if we want to push images to Dcokerhub:

https://github.com/docker/login-action