### PR TITLE
Override notebooks within Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,14 +93,14 @@ Requires 'weaver' component to be active on the target 'PAVICS_HOST' server
                 description: 'Extra options to pass to pytest, e.g. --nbval-lax --dist=loadscope --numprocesses=0', trim: true)
         string(name: 'EXTRA_TEST_ENV_VAR', defaultValue: '',
                 description: 'Extra environment variables for the various tests, ex: "TEST_RUNS=50 TEST_WPS_BIRDS=finch,raven,flyingpigeon TEST_NO_USE_PROD_DATA=1"', trim: true)
+        string(name: 'ALLOWLIST_NOTEBOOKS', defaultValue: '',
+                description: 'Optional: space-separated list of notebook paths to run.  Top-most root should resemble {project name}-{branch}.  If empty, all discovered notebooks will be run without filtering.  e.g. pavics-sdi-master/docs/source/notebooks/WCS_example.ipynb pavics-sdi-master/docs/source/notebooks/regridding.ipynb finch-main/docs/source/notebooks/finch-usage.ipynb', trim: true)
         string(name: 'CONFIG_OVERRIDE_SCRIPT_URL', defaultValue: '',
                 description: 'Url or local file path to a script that will be sourced, allowing to programmatically override additional configs right before testsuite starts. e.g. https://raw.githubusercontent.com/Ouranosinc/PAVICS-e2e-workflow-tests/master/test-override/geoserver-nb-only.include.sh', trim: true)
         booleanParam(name: 'TEST_LOCAL_NOTEBOOKS', defaultValue: true,
                 description: 'Check the box to test notebooks in this repo (./notebooks/*.ipynb).')
         booleanParam(name: 'VERIFY_SSL', defaultValue: true,
                 description: 'Check the box to verify SSL certificate for https connections to PAVICS host.')
-        string(name: 'CUSTOM_NOTEBOOKS', defaultValue: '',
-                description: 'Optional: space-separated list of notebook paths to run.  Top-most root should resemble {project name}-{branch}.  If empty, defaults will be used.  e.g. pavics-sdi-master/docs/source/notebooks/WCS_example.ipynb pavics-sdi-master/docs/source/notebooks/regridding.ipynb finch-main/docs/source/notebooks/finch-usage.ipynb', trim: true)
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,
                 description: '''Check the box to save the resulting notebooks of the run.
 Note this is another run, will double the time and no guaranty to have same error as the run from py.test.''')

--- a/testall
+++ b/testall
@@ -121,9 +121,9 @@ if [ x"$TEST_LOCAL_NOTEBOOKS" = xtrue ]; then
     NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST notebooks/*.ipynb"
 fi
 
-if [ x"$CUSTOM_NOTEBOOKS" != x ]; then
-  # Custom notebooks to test, can be set by Jenkins job parameters.
-  NOTEBOOKS_TO_TEST="$CUSTOM_NOTEBOOKS"
+if [ x"$ALLOWLIST_NOTEBOOKS" != x ]; then
+  # Allowlist of notebooks to test, can be set by Jenkins job parameters.
+  NOTEBOOKS_TO_TEST="$ALLOWLIST_NOTEBOOKS"
 fi
 
 # last notebooks higher chance for name clash


### PR DESCRIPTION
# Overview

This PR adds a new filtering mechanism to make it easier to quickly run tests against individual notebooks.

## Changes

- Modifies the Jenkinsfile to accept a new `ALLOWLIST_NOTEBOOKS` field for providing a filter for notebooks to be run

## Testing Checklist

- Manually tested and verified working on Jenkins

## Related Issue / Discussion

The functionality was already possible by setting a gist with a filtering function and setting `CONFIG_PARAMETERS_SCRIPT_URL` to pick up the script, overriding existing settings.

The changes here make it so that this can simply be performed directly on Jenkins.