### PR TITLE
replace GeoServer DataStore PUT->POST request

### DIFF
--- a/notebooks-auth/geoserver.ipynb
+++ b/notebooks-auth/geoserver.ipynb
@@ -333,7 +333,7 @@
     "        },\n",
     "    }\n",
     "}\n",
-    "geoserver_admin_session.put(url=f\"{GEOSERVER_REST_URL}/workspaces/{workspace_name}/datastores/{datastore_name}\", json=payload)\n",
+    "geoserver_admin_session.post(url=f\"{GEOSERVER_REST_URL}/workspaces/{workspace_name}/datastores/{datastore_name}\", json=payload)\n",
     "\n",
     "if resp.status_code != 201:\n",
     "    cleanup_test_data()\n",


### PR DESCRIPTION
# Overview

Testing out issue/workaround identified in https://github.com/bird-house/birdhouse-deploy/pull/570

No idea if it will work as-is or not. 
Starting the test-suite with both branch references in Jenkins.
~http://daccs-jenkins.crim.ca/job/DACCS-iac-birdhouse/3747/~

**edit**: http://daccs-jenkins.crim.ca/job/DACCS-iac-birdhouse/3752
(previous run failed to start due to problematic jobs queue)

## Changes

- replace GeoServer DataStore PUT->POST request in notebook-auth setup for Cowbird/Magpie/GeoServer interactions

## Related Issue / Discussion

- https://github.com/bird-house/birdhouse-deploy/pull/570
