### PR TITLE
Add build tools

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -116,7 +116,7 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_
     rm -v /usr/local/bin/globusconnectpersonal-latest.tgz
 
 # For jupyter-panel-proxy launcher.
-ENV BOKEH_ALLOW_WS_ORIGIN "*"
+ENV BOKEH_ALLOW_WS_ORIGIN="*"
 
 # For import xesmf since esmf-8.4.0, see: https://github.com/conda-forge/esmf-feedstock/issues/91
 ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
@@ -126,8 +126,8 @@ ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
 ENV PROJ_DATA="/opt/conda/envs/birdy/share/proj"
 
 # To expose conda-installed compilers so that users can make use of them
+ENV gcc=x86_64-conda-linux-gnu-gcc
 ENV g++=x86_64-conda-linux-gnu-g++
-ENV gxx=x86_64-conda-linux-gnu-gxx
 ENV gfortran=x86_64-conda-linux-gnu-gfortran
 
 # problem running start-notebook.sh when being root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,7 @@ ENV MAMBA_ROOT_PREFIX="/opt/conda"
 # to checkout other notebooks and to run pip install
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    git mercurial gcc unzip patch fonts-humor-sans \
-    firefox-esr x11-utils && \
+    git mercurial gcc unzip patch fonts-humor-sans firefox-esr x11-utils && \
     apt-get clean
 
 # Create user jenkins for our Jenkins e2e notebooks test suite.
@@ -119,14 +118,17 @@ RUN wget https://raw.githubusercontent.com/jupyter/docker-stacks/$DOCKER_STACKS_
 # For jupyter-panel-proxy launcher.
 ENV BOKEH_ALLOW_WS_ORIGIN "*"
 
-# For import xesmf since esmf-8.4.0, see
-# https://github.com/conda-forge/esmf-feedstock/issues/91
+# For import xesmf since esmf-8.4.0, see: https://github.com/conda-forge/esmf-feedstock/issues/91
 ENV ESMFMKFILE="/opt/conda/envs/birdy/lib/esmf.mk"
 
-# To avoid error "PROJ: proj_create_from_database: Open of
-# /opt/conda/envs/birdy/share/proj failed"
+# To avoid error "PROJ: proj_create_from_database: Open of /opt/conda/envs/birdy/share/proj failed"
 # This simulates a real `conda activate birdy`.
 ENV PROJ_DATA="/opt/conda/envs/birdy/share/proj"
+
+# To expose conda-installed compilers so that users can make use of them
+ENV g++=x86_64-conda-linux-gnu-g++
+ENV gxx=x86_64-conda-linux-gnu-gxx
+ENV gfortran=x86_64-conda-linux-gnu-gfortran
 
 # problem running start-notebook.sh when being root
 # the jupyter/base-notebook image also do not default to root user so we do the same here

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -5,6 +5,7 @@ channels:
   - cdat
   - bokeh
   - fortiers  # for fstd2nc
+  - nodefaults
 dependencies:
   # clisops direct dependencies: https://github.com/conda-forge/clisops-feedstock/blob/master/recipe/meta.yaml
   # figanos direct dependencies: https://github.com/conda-forge/figanos-feedstock/blob/master/recipe/meta.yaml
@@ -34,6 +35,20 @@ dependencies:
   - xscen >= 0.12.3
   # xsdba: Statistical correction and bias adjustment tools for xarray.
   - xsdba >= 0.5.0
+
+  ## BUILD TOOLS
+  # Only add pins here as needed
+
+  # make: tool which controls the generation of executables and other non-source files of a program from the program's source files
+  - make
+  # cmake: cross-platform, open-source build system
+  - cmake
+    # c-compiler: C compiler meta-package
+  - c-compiler
+  # cxx-compiler: C++ compiler meta-package
+  - cxx-compiler
+  # fortran-compiler: Fortran compiler meta-package
+  - fortran-compiler
 
   ## COMMON LIBRARIES
   # Only add pins here as needed

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   # Installation proceeds in two phases in the Dockerfile in order to avoid memory usage issues.
   # Mamba is quicker to solve dependencies than conda, but it is less precise so accidental downgrades can happen.
 
-  ## CORE LIBRARIES
+  # CORE LIBRARIES
 
   # clisops: Data reduction operations on xarray climate data
   - clisops >= 0.16.2
@@ -36,21 +36,7 @@ dependencies:
   # xsdba: Statistical correction and bias adjustment tools for xarray.
   - xsdba >= 0.5.0
 
-  ## BUILD TOOLS
-  # Only add pins here as needed
-
-  # make: tool which controls the generation of executables and other non-source files of a program from the program's source files
-  - make
-  # cmake: cross-platform, open-source build system
-  - cmake
-    # c-compiler: C compiler meta-package
-  - c-compiler
-  # cxx-compiler: C++ compiler meta-package
-  - cxx-compiler
-  # fortran-compiler: Fortran compiler meta-package
-  - fortran-compiler
-
-  ## COMMON LIBRARIES
+  # COMMON LIBRARIES
   # Only add pins here as needed
 
   # cartopy: Python library for cartographic projections and geospatial data visualization
@@ -328,3 +314,16 @@ dependencies:
 
   # PIP PACKAGE SUPPORT
   - pip # Needed for pip packages
+
+  # BUILD TOOLS
+
+  # make: tool which controls the generation of executables and other non-source files of a program from the program's source files
+  - make
+  # cmake: cross-platform, open-source build system
+  - cmake
+    # c-compiler: C compiler meta-package
+  - c-compiler
+  # cxx-compiler: C++ compiler meta-package
+  - cxx-compiler
+  # fortran-compiler: Fortran compiler meta-package
+  - fortran-compiler

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -312,11 +312,14 @@ dependencies:
   # xlrd: Python library for reading data and formatting information from legacy Excel files
   - xlrd
 
-  # PIP PACKAGE SUPPORT
-  - pip # Needed for pip packages
+  # PIP PACKAGING SUPPORT
+  - pip >= 25.2 # Needed for modern pip packages
 
   # BUILD TOOLS
 
+  # C and Fortran NetCDF library support
+  - libnetcdf
+  - netcdf-fortran
   # make: tool which controls the generation of executables and other non-source files of a program from the program's source files
   - make
   # cmake: cross-platform, open-source build system


### PR DESCRIPTION
# Overview

This PR fixes #156 by adding relevant build packages to the Conda environment for compilation of C, C++, and Fortran libraries.

## Changes

- Adds: 
  - `make` (build runner for `*nix` systems)
  - `cmake` (cross-platform build runner, specific for `raven-hydro`)
  - `c-compiler` (metapackage for C)
  - `cxx-compiler` (metapackage for C++)
  - `fortran-compiler` (metapackage for FORTRAN)
  - `libnetcdf` (NetCDF4 C Library)
  - `netcdf-fortran` (NetCDF4 FORTRAN Library)

## Testing Checklist

- [x] Manually verified whether build tools can be called as a user of PAVICS

## Related Issue / Discussion

This PR does not require an immediate release. All this does is add the build-essential libraries so that users building and running C/C++/Fortran libraries no longer need to install those compilers manually in their Conda environments.
