### PR TITLE
Clean copyright year from notebooks

### DIFF
--- a/notebooks/output-sanitize.cfg
+++ b/notebooks/output-sanitize.cfg
@@ -30,6 +30,10 @@ replace: [DATE_TIME]
 regex: [\/| ]\d{4}-\d{2}-\d{2}[\/| ]
 replace: /DATE/
 
+[copyright_year]
+regex: \(\d{4}\)
+replace: (COPYRIGHT_YEAR)
+
 [time_stamp]
 regex: [\/| ]\d{2}:\d{2}:\d{2}[\/| ]
 replace: /TIME/


### PR DESCRIPTION
# Overview

<!-- Please include a summary of the changes and which issues is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes [PAVICS-Landing #121](https://github.com/Ouranosinc/PAVICS-landing/issues/121) by sanitizing strings that likely contain copyright years (which often change in January for some unexplainable reason). 

<!-- NOTE: Remember to tag 'release-py###-######' on the commit of this merge. -->

## Changes

- Adds a regex rule for cleaning up years in comment strings (`\(\d{4}\)`)