### PR TITLE
Add some xHydro notebooks to Jenkins, enabled by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,12 @@ Requires 'weaver' component to be active on the target 'PAVICS_HOST' server
                 description: 'RAVENPY_REPO branch to test against.', trim: true)
         string(name: 'RAVENPY_REPO', defaultValue: 'CSHS-CWRA/RavenPy',
                 description: 'https://github.com/CSHS-CWRA/RavenPy repo or fork to test against.', trim: true)
+        booleanParam(name: 'TEST_XHYDRO_REPO', defaultValue: true,
+                description: 'Check the box to test xHydro repo.')
+        string(name: 'XHYDRO_BRANCH', defaultValue: 'main',
+                description: 'XHYDRO_REPO branch to test against.', trim: true)
+        string(name: 'XHYDRO_REPO', defaultValue: 'hydrologie/xhydro',
+                description: 'https://github.com/hydrologie/xhydro repo or fork to test against.', trim: true)
         booleanParam(name: 'TEST_ESGF_COMPUTE_API_REPO', defaultValue: false,
                 description: 'Check the box to test esgf-compute-api repo.  Kept here for historical reasons only, not working anymore.')
         string(name: 'ESGF_COMPUTE_API_BRANCH', defaultValue: 'devel',

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -10,10 +10,10 @@ rm -r esgf-compute-api-$ESGF_COMPUTE_API_BRANCH
 mkdir hydro
 mv -v raven-${RAVEN_BRANCH}/docs/source/notebooks/*.ipynb ./hydro/
 mv -v RavenPy-${RAVENPY_BRANCH}/docs/notebooks/*.ipynb ./hydro/
-mv -v xHydro-${XHYDRO_BRANCH}/docs/notebooks/pavics_notebooks/*.ipynb ./hydro/
+mv -v xhydro-${XHYDRO_BRANCH}/docs/notebooks/pavics_notebooks/*.ipynb ./hydro/
 mkdir hydro/paper
 mv -v RavenPy-${RAVENPY_BRANCH}/docs/notebooks/paper/*.ipynb ./hydro/paper/
-rm -r raven-${RAVEN_BRANCH} RavenPy-${RAVENPY_BRANCH} xHydro-${XHYDRO_BRANCH}
+rm -r raven-${RAVEN_BRANCH} RavenPy-${RAVENPY_BRANCH} xhydro-${XHYDRO_BRANCH}
 
 if [ -n "$DEPLOY_PAVICS_LANDING_NB" ]; then
     # Pavics landing notebooks already deployed to Jupyter env via

--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -10,9 +10,10 @@ rm -r esgf-compute-api-$ESGF_COMPUTE_API_BRANCH
 mkdir hydro
 mv -v raven-${RAVEN_BRANCH}/docs/source/notebooks/*.ipynb ./hydro/
 mv -v RavenPy-${RAVENPY_BRANCH}/docs/notebooks/*.ipynb ./hydro/
+mv -v xHydro-${XHYDRO_BRANCH}/docs/notebooks/pavics_notebooks/*.ipynb ./hydro/
 mkdir hydro/paper
 mv -v RavenPy-${RAVENPY_BRANCH}/docs/notebooks/paper/*.ipynb ./hydro/paper/
-rm -r raven-${RAVEN_BRANCH} RavenPy-${RAVENPY_BRANCH}
+rm -r raven-${RAVEN_BRANCH} RavenPy-${RAVENPY_BRANCH} xHydro-${XHYDRO_BRANCH}
 
 if [ -n "$DEPLOY_PAVICS_LANDING_NB" ]; then
     # Pavics landing notebooks already deployed to Jupyter env via

--- a/default_build_params
+++ b/default_build_params
@@ -105,6 +105,27 @@ else
     echo "RAVENPY_REPO has been set to '$RAVENPY_REPO'"
 fi
 
+if [ -z "$TEST_XHYDRO_REPO" ]; then
+    TEST_XHYDRO_REPO=true
+    echo "TEST_XHYDRO_REPO not set, default to '$TEST_XHYDRO_REPO'"
+else
+    echo "TEST_XHYDRO_REPO has been set to '$TEST_XHYDRO_REPO'"
+fi
+
+if [ -z "$XHYDRO_BRANCH" ]; then
+    XHYDRO_BRANCH=main
+    echo "XHYDRO_BRANCH not set, default to '$XHYDRO_BRANCH'"
+else
+    echo "XHYDRO_BRANCH has been set to '$XHYDRO_BRANCH'"
+fi
+
+if [ -z "$XHYDRO_REPO" ]; then
+    XHYDRO_REPO='hydrologie/xhydro'
+    echo "XHYDRO_REPO not set, default to '$XHYDRO_REPO'"
+else
+    echo "XHYDRO_REPO has been set to '$XHYDRO_REPO'"
+fi
+
 if [ -z "$TEST_ESGF_COMPUTE_API_REPO" ]; then
     TEST_ESGF_COMPUTE_API_REPO=false
     echo "TEST_ESGF_COMPUTE_API_REPO not set, default to '$TEST_ESGF_COMPUTE_API_REPO'"

--- a/downloadrepos
+++ b/downloadrepos
@@ -47,6 +47,7 @@ lowercase_boolean_build_params() {
     TEST_PAVICS_LANDING_REPO="$(lowercase "$TEST_PAVICS_LANDING_REPO")"
     TEST_RAVEN_REPO="$(lowercase "$TEST_RAVEN_REPO")"
     TEST_RAVENPY_REPO="$(lowercase "$TEST_RAVENPY_REPO")"
+    TEST_XHYDRO_REPO="$(lowercase "$TEST_XHYDRO_REPO")"
     TEST_ESGF_COMPUTE_API_REPO="$(lowercase "$TEST_ESGF_COMPUTE_API_REPO")"
     TEST_LOCAL_NOTEBOOKS="$(lowercase "$TEST_LOCAL_NOTEBOOKS")"
 }
@@ -98,6 +99,9 @@ downloadrepos_main() {
         fi
         if [ x"$DOWNLOAD_ALL_DEFAULT_REPOS" = xtrue ] || [ x"$TEST_RAVENPY_REPO" = xtrue ]; then
             downloadgithubrepos $RAVENPY_REPO $RAVENPY_BRANCH
+        fi
+        if [ x"$DOWNLOAD_ALL_DEFAULT_REPOS" = xtrue ] || [ x"$TEST_XHYDRO_REPO" = xtrue ]; then
+            downloadgithubrepos $XHYDRO_REPO $XHYDRO_BRANCH
         fi
         if [ x"$DOWNLOAD_ALL_DEFAULT_REPOS" = xtrue ] || [ x"$TEST_ESGF_COMPUTE_API_REPO" = xtrue ]; then
             downloadgithubrepos $ESGF_COMPUTE_API_REPO $ESGF_COMPUTE_API_BRANCH

--- a/test-override/jenkins-params-external-repos.include.sh
+++ b/test-override/jenkins-params-external-repos.include.sh
@@ -15,6 +15,7 @@ TEST_PAVICS_LANDING_REPO="false"
 TEST_LOCAL_NOTEBOOKS="false"
 TEST_RAVEN_REPO="false"
 TEST_RAVENPY_REPO="false"
+TEST_XHYDRO_REPO="false"
 
 # Set new external repo vars.  Need 'export' so CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL can see them.
 export ROOK_REPO="roocs/rook"

--- a/test-override/jenkins-params-geoserver-nb-only.include.sh
+++ b/test-override/jenkins-params-geoserver-nb-only.include.sh
@@ -9,6 +9,7 @@ TEST_PAVICS_LANDING_REPO="true"
 TEST_LOCAL_NOTEBOOKS="true"
 TEST_RAVEN_REPO="true"
 TEST_RAVENPY_REPO="true"
+TEST_XHYDRO_REPO="true"
 
 # Force use the local GeoServer, to test the local GeoServer.  Otherwise the
 # production GeoServer will be used, which defeat the purpose of the test.
@@ -30,3 +31,4 @@ export CONFIG_OVERRIDE_SCRIPT_URL
 #PAVICS_LANDING_BRANCH=""
 #RAVEN_BRANCH=""
 #RAVENPY_BRANCH=""
+#XHYDRO_BRANCH=""

--- a/test-override/jenkins-params-raven-nb-only.include.sh
+++ b/test-override/jenkins-params-raven-nb-only.include.sh
@@ -7,6 +7,7 @@
 TEST_PAVICS_SDI_REPO="false"
 TEST_FINCH_REPO="false"
 TEST_PAVICS_LANDING_REPO="false"
+TEST_XHYDRO_REPO="false"
 TEST_LOCAL_NOTEBOOKS="false"
 
 # Enable raven repos.

--- a/testall
+++ b/testall
@@ -83,7 +83,7 @@ NOTEBOOKS_TO_TEST=""
 # So that empty dir do not break us.  Empty dir happens when we prepare in
 # advance a new repo, the folder we reference is not yet merged to that repo.
 accumulate_notebooks_to_test() {
-    if ls -1 $1 >& /dev/null; then
+    if ls -1 $1; then
         NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $1"
     else
         echo "ERROR: '$1' is empty."

--- a/testall
+++ b/testall
@@ -79,22 +79,33 @@ if [ x"$VERIFY_SSL" = xfalse ]; then
 fi
 
 NOTEBOOKS_TO_TEST=""
+
+# So that empty dir do not break us.  Empty dir happens when we prepare in
+# advance a new repo, the folder we reference is not yet merged to that repo.
+accumulate_notebooks_to_test() {
+    if ls -1 $1 >& /dev/null; then
+        NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST $1"
+    else
+        echo "ERROR: '$1' is empty."
+    fi
+}
+
 if [ x"$TEST_MAGPIE_AUTH" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST notebooks-auth/*.ipynb"
+    accumulate_notebooks_to_test "notebooks-auth/*.ipynb"
 fi
 if [ x"$TEST_PAVICS_SDI_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${PAVICS_SDI_DIR}/docs/source/notebooks/*.ipynb"
+    accumulate_notebooks_to_test "${PAVICS_SDI_DIR}/docs/source/notebooks/*.ipynb"
     if [ x"$TEST_PAVICS_SDI_WEAVER" = xtrue ]; then
-        NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${PAVICS_SDI_DIR}/docs/source/notebook-components/*weaver*.ipynb"
+        accumulate_notebooks_to_test "${PAVICS_SDI_DIR}/docs/source/notebook-components/*weaver*.ipynb"
     fi
 fi
 if [ x"$TEST_FINCH_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${FINCH_DIR}/docs/source/notebooks/*.ipynb"
+    accumulate_notebooks_to_test "${FINCH_DIR}/docs/source/notebooks/*.ipynb"
 fi
 
 if [ x"$TEST_PAVICS_LANDING_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${PAVICS_LANDING_DIR}/content/notebooks/climate_indicators/*.ipynb"
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${PAVICS_LANDING_DIR}/content/notebooks/hydrology/*.ipynb"
+    accumulate_notebooks_to_test "${PAVICS_LANDING_DIR}/content/notebooks/climate_indicators/*.ipynb"
+    accumulate_notebooks_to_test "${PAVICS_LANDING_DIR}/content/notebooks/hydrology/*.ipynb"
 
     SETUP_SCRIPT="${PAVICS_LANDING_DIR}/content/notebooks/climate_indicators/setup_dirlayout.sh"
     if [ -x "$SETUP_SCRIPT" ]; then
@@ -108,23 +119,23 @@ if [ x"$TEST_PAVICS_LANDING_REPO" = xtrue ]; then
 fi
 
 if [ x"$TEST_RAVEN_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${RAVEN_DIR}/docs/source/notebooks/*.ipynb"
+    accumulate_notebooks_to_test "${RAVEN_DIR}/docs/source/notebooks/*.ipynb"
 fi
 if [ x"$TEST_RAVENPY_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${RAVENPY_DIR}/docs/notebooks/*.ipynb"
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${RAVENPY_DIR}/docs/notebooks/paper/*.ipynb"
+    accumulate_notebooks_to_test "${RAVENPY_DIR}/docs/notebooks/*.ipynb"
+    accumulate_notebooks_to_test "${RAVENPY_DIR}/docs/notebooks/paper/*.ipynb"
 fi
 if [ x"$TEST_XHYDRO_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${XHYDRO_DIR}/docs/notebooks/pavics_notebooks/*.ipynb"
+    accumulate_notebooks_to_test "${XHYDRO_DIR}/docs/notebooks/pavics_notebooks/*.ipynb"
 fi
 if [ x"$TEST_ESGF_COMPUTE_API_REPO" = xtrue ]; then
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${ESGF_COMPUTE_API_DIR}/examples/*.ipynb"
+    accumulate_notebooks_to_test "${ESGF_COMPUTE_API_DIR}/examples/*.ipynb"
 fi
 
 if [ x"$TEST_LOCAL_NOTEBOOKS" = xtrue ]; then
     # Add notebooks here last since stress-test.ipynb can possible cause cascading
     # damage to other notebooks.
-    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST notebooks/*.ipynb"
+    accumulate_notebooks_to_test "notebooks/*.ipynb"
 fi
 
 if [ x"$ALLOWLIST_NOTEBOOKS" != x ]; then

--- a/testall
+++ b/testall
@@ -54,6 +54,8 @@ export RAVEN_BRANCH="$(sanitize_branch_name "$RAVEN_BRANCH")"
 export RAVEN_REPO_NAME="$(extract_repo_name "$RAVEN_REPO")"
 export RAVENPY_BRANCH="$(sanitize_branch_name "$RAVENPY_BRANCH")"
 export RAVENPY_REPO_NAME="$(extract_repo_name "$RAVENPY_REPO")"
+export XHYDRO_BRANCH="$(sanitize_branch_name "$XHYDRO_BRANCH")"
+export XHYDRO_REPO_NAME="$(extract_repo_name "$XHYDRO_REPO")"
 export ESGF_COMPUTE_API_BRANCH="$(sanitize_branch_name "$ESGF_COMPUTE_API_BRANCH")"
 export ESGF_COMPUTE_API_REPO_NAME="$(extract_repo_name "$ESGF_COMPUTE_API_REPO")"
 
@@ -62,6 +64,7 @@ export FINCH_DIR="$(sanitize_extracted_folder_name "${FINCH_REPO_NAME}-${FINCH_B
 export PAVICS_LANDING_DIR="$(sanitize_extracted_folder_name "${PAVICS_LANDING_REPO_NAME}-${PAVICS_LANDING_BRANCH}")"
 export RAVEN_DIR="$(sanitize_extracted_folder_name "${RAVEN_REPO_NAME}-${RAVEN_BRANCH}")"
 export RAVENPY_DIR="$(sanitize_extracted_folder_name "${RAVENPY_REPO_NAME}-${RAVENPY_BRANCH}")"
+export XHYDRO_DIR="$(sanitize_extracted_folder_name "${XHYDRO_REPO_NAME}-${XHYDRO_BRANCH}")"
 export ESGF_COMPUTE_API_DIR="$(sanitize_extracted_folder_name "${ESGF_COMPUTE_API_REPO_NAME}-${ESGF_COMPUTE_API_BRANCH}")"
 
 # lowercase VERIFY_SSL string
@@ -110,6 +113,9 @@ fi
 if [ x"$TEST_RAVENPY_REPO" = xtrue ]; then
     NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${RAVENPY_DIR}/docs/notebooks/*.ipynb"
     NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${RAVENPY_DIR}/docs/notebooks/paper/*.ipynb"
+fi
+if [ x"$TEST_XHYDRO_REPO" = xtrue ]; then
+    NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${XHYDRO_DIR}/docs/notebooks/pavics_notebooks/*.ipynb"
 fi
 if [ x"$TEST_ESGF_COMPUTE_API_REPO" = xtrue ]; then
     NOTEBOOKS_TO_TEST="$NOTEBOOKS_TO_TEST ${ESGF_COMPUTE_API_DIR}/examples/*.ipynb"


### PR DESCRIPTION
Add some xHydro notebooks to Jenkins, enabled by default.

Also ensure empty notebook dir do not break us.   This happens because xHydro PR (https://github.com/hydrologie/xhydro/pull/414) that moved the notebooks to a new folder is not merged yet so that dir is currently empty on `main` branch of xHydro.