### PR TITLE
fix geoserver secured test with latest API restrictions

### DIFF
--- a/notebooks-auth/geoserver.ipynb
+++ b/notebooks-auth/geoserver.ipynb
@@ -5,34 +5,29 @@
    "id": "9fcee1d6-2d2e-4f2b-90a1-c2c7383f2393",
    "metadata": {},
    "source": [
-    "# Accessing Geoserver data\n",
+    "# Accessing GeoServer data\n",
     "\n",
-    "This notebooks tests the access to different Geoserver resources and checks that the different user permissions from Magpie are respected."
+    "This notebooks tests the access to different GeoServer resources and checks that the different user permissions from Magpie are respected.\n",
+    "\n",
+    "This notebook expects that the evaluated server instance has the following components properly configured:\n",
+    "- [`components/geoserver`](https://github.com/bird-house/birdhouse-deploy/tree/master/birdhouse/components/geoserver)\n",
+    "- [`optional-components/test-geoserver-secured-access`](https://github.com/bird-house/birdhouse-deploy/tree/master/birdhouse/optional-components/test-geoserver-secured-access)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
    "id": "3dbaa1f2-4cb3-4e6a-a71e-f7987d460fbf",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Setup configuration parameters...\n",
-      "  Will use Magpie URL:   [https://pavics.ouranos.ca/magpie]\n",
-      "  Will use Geoserver URL:   [https://pavics.ouranos.ca/geoserver]\n",
-      "  Will use Geoserver rest URL:  [https://pavics.ouranos.ca/geoserver/rest]\n"
-     ]
+    "tags": [],
+    "ExecuteTime": {
+     "end_time": "2026-04-02T23:45:06.410011445Z",
+     "start_time": "2026-04-02T23:45:06.186123869Z"
     }
-   ],
+   },
    "source": [
     "# define some useful variables for following steps\n",
     "import copy\n",
@@ -55,8 +50,11 @@
     "\n",
     "TEST_DISABLE_CLEANUP = str(os.getenv(\"TEST_DISABLE_CLEANUP\", False)).lower() in [\"true\", \"1\", \"on\"]\n",
     "\n",
+    "TEST_PROXY_SCHEME = os.getenv(\"TEST_PROXY_SCHEME\", \"https\")\n",
+    "TEST_SERVER_URL = str(os.getenv(\"TEST_SERVER_URL\") or f\"{TEST_PROXY_SCHEME}://{PAVICS_HOST}\").rstrip(\"/\")\n",
+    "\n",
     "# Magpie variables\n",
-    "MAGPIE_URL = f\"https://{PAVICS_HOST}/magpie\"\n",
+    "MAGPIE_URL = f\"{TEST_SERVER_URL}/magpie\"\n",
     "\n",
     "def get_credentials(var_name):\n",
     "    value = os.getenv(var_name)\n",
@@ -76,8 +74,8 @@
     "\n",
     "# Geoserver variables\n",
     "GEOSERVER_SERVICE = os.getenv(\"GEOSERVER_SERVICE\") or \"geoserver\"\n",
-    "GEOSERVER_URL = f\"https://{PAVICS_HOST}/{GEOSERVER_SERVICE}\"\n",
-    "GEOSERVER_REST_URL = f\"https://{PAVICS_HOST}/geoserver/rest\"\n",
+    "GEOSERVER_URL = f\"{TEST_SERVER_URL}/{GEOSERVER_SERVICE}\"\n",
+    "GEOSERVER_REST_URL = f\"{TEST_SERVER_URL}/geoserver/rest\"\n",
     "\n",
     "workspace_name = \"test_workspace\"\n",
     "datastore_name = \"test_datastore\"\n",
@@ -87,20 +85,82 @@
     "print(\"  Will use Magpie URL:   [{}]\".format(MAGPIE_URL))\n",
     "print(\"  Will use Geoserver URL:   [{}]\".format(GEOSERVER_URL))\n",
     "print(\"  Will use Geoserver rest URL:  [{}]\".format(GEOSERVER_REST_URL))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setup configuration parameters...\n",
+      "  Will use Magpie URL:   [https://pavics.ouranos.ca/magpie]\n",
+      "  Will use Geoserver URL:   [https://pavics.ouranos.ca/geoserver]\n",
+      "  Will use Geoserver rest URL:  [https://pavics.ouranos.ca/geoserver/rest]\n"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-02T23:45:17.020919419Z",
+     "start_time": "2026-04-02T23:45:16.943145181Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# check that expected components are present\n",
+    "# if not, don't fail to allow flexibility with other setups, but at least make it clear that it might be the cause of failure\n",
+    "components_url = f\"{TEST_SERVER_URL}/components\"\n",
+    "components_resp = requests.request(url=components_url, headers=HEADERS, method=\"GET\", timeout=10, verify=VERIFY_SSL)\n",
+    "components_src = \"bird-house/birdhouse-deploy\"\n",
+    "components_req = [\n",
+    "    f\"{components_src}:components/geoserver\",\n",
+    "    f\"{components_src}:optional-components/test-geoserver-secured-access\",\n",
+    "]\n",
+    "components = []\n",
+    "if components_resp.status_code != 200:\n",
+    "    print(\n",
+    "        f\"⚠️ WARNING: Could not validate components offered by the server. \"\n",
+    "        f\"Got [{components_resp.status_code}] from [{components_url}].\"\n",
+    "    )\n",
+    "else:\n",
+    "    components = components_resp.json().get(\"components\") or []\n",
+    "if not all(comp_req in components for comp_req in components_req):\n",
+    "    print(\n",
+    "        f\"⚠️ WARNING: Expected components not found in the server. \"\n",
+    "        f\"Expected to find:\\n{json.dumps(sorted(components_req), indent=2)}\\n\"\n",
+    "        f\"in:\\n{json.dumps(sorted(components), indent=2)}\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"✅ Expected components found in the server, proceeding with tests.\")"
+   ],
+   "id": "d7777b6234d02c4b",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Expected components found in the server, proceeding with tests.\n"
+     ]
+    }
+   ],
+   "execution_count": 4
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "id": "e2a6afdd-c5e4-4ac0-9674-de352f04b632",
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [],
+    "ExecuteTime": {
+     "end_time": "2026-04-02T23:45:17.849060810Z",
+     "start_time": "2026-04-02T23:45:17.825678978Z"
+    }
    },
-   "outputs": [],
    "source": [
     "def magpie_signin(user_name, password):\n",
     "    signin_url = f\"{MAGPIE_URL}/signin\"\n",
@@ -113,14 +173,19 @@
     "    if resp.status_code != 200:\n",
     "        raise RuntimeError(f\"Unexpected response while trying to sign in to Magpie with user `{user_name}` : {resp.text}\")\n",
     "    return resp"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 5
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "id": "9cfcdeb5-00b4-4043-b06d-aef467232157",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-02T23:45:18.607150699Z",
+     "start_time": "2026-04-02T23:45:18.565543551Z"
+    }
+   },
    "source": [
     "magpie_admin_session = requests.Session()\n",
     "magpie_admin_session.verify = VERIFY_SSL\n",
@@ -137,14 +202,19 @@
     "no_perm_user_session = requests.Session()\n",
     "no_perm_user_session.verify = VERIFY_SSL\n",
     "no_perm_user_session.headers = HEADERS"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 6
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "id": "245dbbb5-a623-4f40-8788-2ba6120254f5",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-02T23:45:19.404757631Z",
+     "start_time": "2026-04-02T23:45:19.383587287Z"
+    }
+   },
    "source": [
     "def response_msg(message, response, is_json=True):\n",
     "    \"\"\"Append useful response details to provided message.\"\"\"\n",
@@ -158,14 +228,19 @@
     "            # ignore and revert to text body since it could not be parsed as JSON\n",
     "            _body = response.text\n",
     "    return \"{} Response replied with ({}) [{}]\\nContent: {}\\n\\n\".format(message, response.status_code, _detail, _body)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 7
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "id": "7a511c6a-8555-4e68-b6fc-a7b688fd4a6f",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-02T23:56:30.729817397Z",
+     "start_time": "2026-04-02T23:56:30.672946674Z"
+    }
+   },
    "source": [
     "CLEANUP_CALLED = False\n",
     "\n",
@@ -191,10 +266,10 @@
     "    secured_geoserver_found = False\n",
     "    resp = magpie_admin_session.get(f\"{MAGPIE_URL}/services/{GEOSERVER_SERVICE}\")\n",
     "    if resp.status_code == 200:\n",
-    "        \n",
+    "\n",
     "        geoserver_res_id = resp.json()[\"service\"][\"resource_id\"]\n",
     "        _resp = magpie_admin_session.get(f\"{MAGPIE_URL}/resources/{geoserver_res_id}\")\n",
-    "        \n",
+    "\n",
     "        if _resp.status_code == 200:\n",
     "            secured_geoserver_found = True\n",
     "            _children = _resp.json()[\"resource\"][\"children\"]\n",
@@ -204,7 +279,7 @@
     "    if not secured_geoserver_found:\n",
     "        print(f\"Failed to find the `{GEOSERVER_SERVICE}` service, which is expected to exist.\")\n",
     "        failed = True\n",
-    "    \n",
+    "\n",
     "    # Apply cleanup of Magpie items\n",
     "    for item_type, item_name, item_value in magpie_items:\n",
     "        try:\n",
@@ -222,7 +297,7 @@
     "        except Exception as exc:\n",
     "            print(\"Magpie cleanup raised: [{}]\".format(exc))\n",
     "            failed = True\n",
-    "    \n",
+    "\n",
     "    # Cleanup Geoserver workspace (must remove each resource step by step)\n",
     "    for path in [\n",
     "        f\"{GEOSERVER_REST_URL}/layers/{shapefile_name}\",\n",
@@ -244,10 +319,12 @@
     "        except Exception as exc:\n",
     "            print(\"Geoserver cleanup raised: [{}]\".format(exc))\n",
     "            failed = True\n",
-    "    \n",
+    "\n",
     "    if not skip_fail and failed:\n",
     "        raise ValueError(\"Could not cleanup all test data.\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 14
   },
   {
    "cell_type": "markdown",
@@ -259,10 +336,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "id": "9aa403b3-3a26-47ad-867a-779bdd9a6267",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-02T23:56:40.533975519Z",
+     "start_time": "2026-04-02T23:56:40.473067249Z"
+    }
+   },
    "source": [
     "# create workspace\n",
     "payload = {\"workspace\": {\"name\": workspace_name, \"isolated\": \"True\"}}\n",
@@ -271,38 +351,21 @@
     "if resp.status_code != 201:\n",
     "    cleanup_test_data()\n",
     "    raise ValueError(response_msg(\"\\nFailed to create Geoserver workspace `{}`.\".format(workspace_name), resp))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 15
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
    "id": "66855787-cbc6-4954-b79a-368483cfad11",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:01:26.572899776Z",
+     "start_time": "2026-04-03T00:01:26.495139953Z"
+    }
+   },
    "source": [
     "# create datastore\n",
-    "payload = {\n",
-    "    \"dataStore\": {\n",
-    "        \"name\": datastore_name,\n",
-    "        \"type\": \"Directory of spatial files (shapefiles)\",\n",
-    "        \"connectionParameters\": {\n",
-    "            \"entry\": []\n",
-    "        }}}\n",
-    "resp = geoserver_admin_session.post(url=f\"{GEOSERVER_REST_URL}/workspaces/{workspace_name}/datastores\", json=payload)\n",
-    "\n",
-    "if resp.status_code != 201:\n",
-    "    cleanup_test_data()\n",
-    "    raise ValueError(response_msg(\"\\nFailed to create Geoserver datastore `{}`.\".format(datastore_name), resp))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "550b5910-a26e-46b4-8744-8a5e7aa057e8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# configure datastore\n",
     "payload = {\n",
     "    \"dataStore\": {\n",
     "        \"name\": datastore_name,\n",
@@ -333,19 +396,24 @@
     "        },\n",
     "    }\n",
     "}\n",
-    "geoserver_admin_session.put(url=f\"{GEOSERVER_REST_URL}/workspaces/{workspace_name}/datastores/{datastore_name}\", json=payload)\n",
+    "resp = geoserver_admin_session.post(url=f\"{GEOSERVER_REST_URL}/workspaces/{workspace_name}/datastores\", json=payload)\n",
     "\n",
     "if resp.status_code != 201:\n",
     "    cleanup_test_data()\n",
-    "    raise ValueError(response_msg(\"\\nFailed to configure Geoserver datastore `{}`.\".format(datastore_name), resp))"
-   ]
+    "    raise ValueError(response_msg(\"\\nFailed to create Geoserver datastore `{}`.\".format(datastore_name), resp))"
+   ],
+   "outputs": [],
+   "execution_count": 18
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
    "id": "ac0d25e6-52b9-4463-b970-be223498e55c",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:00.855081699Z",
+     "start_time": "2026-04-03T00:02:00.507452137Z"
+    }
+   },
    "source": [
     "# publish shapefile\n",
     "shapefile_payload = {\n",
@@ -353,7 +421,7 @@
     "        \"name\": shapefile_name,\n",
     "        \"nativeCRS\": \"\"\"\n",
     "                        GEOGCS[\n",
-    "                            \"WGS 84\", \n",
+    "                            \"WGS 84\",\n",
     "                            DATUM[\n",
     "                                \"World Geodetic System 1984\",\n",
     "                                SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]],\n",
@@ -381,7 +449,9 @@
     "if resp.status_code != 201:\n",
     "    cleanup_test_data()\n",
     "    raise ValueError(response_msg(\"\\nFailed to publish shapefile `{}` to Geoserver.\".format(shapefile_name), resp))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 19
   },
   {
    "cell_type": "markdown",
@@ -393,10 +463,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
    "id": "a210971b-9b47-4df7-ab9d-1ba52e042f4e",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:04.135719610Z",
+     "start_time": "2026-04-03T00:02:03.821087Z"
+    }
+   },
    "source": [
     "def create_magpie_user(user_name, password, session):\n",
     "    resp = magpie_admin_session.post(\n",
@@ -414,14 +487,19 @@
     "\n",
     "create_magpie_user(MAGPIE_TEST_USER, MAGPIE_TEST_PASSWORD, test_user_session)\n",
     "create_magpie_user(MAGPIE_NO_PERM_USER, MAGPIE_NO_PERM_PASSWORD, no_perm_user_session)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 20
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
    "id": "e96bf0ff-0fa6-4b96-8bf7-096d69b358eb",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:05.190693115Z",
+     "start_time": "2026-04-03T00:02:04.960883547Z"
+    }
+   },
    "source": [
     "# create/get resources\n",
     "resp = magpie_admin_session.get(f\"{MAGPIE_URL}/services/{GEOSERVER_SERVICE}\")\n",
@@ -456,14 +534,19 @@
     "\n",
     "workspace_res = create_or_get_resource(workspace_name, \"workspace\", geoserver_res_id)\n",
     "layer_res = create_or_get_resource(shapefile_name, \"layer\", workspace_res[\"resource_id\"])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 21
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
    "id": "5ccf2ccd-8481-4d52-ab66-1fafe7a40af9",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:05.687670438Z",
+     "start_time": "2026-04-03T00:02:05.649058621Z"
+    }
+   },
    "source": [
     "def set_permission(permission, resource_id, resource_name, target_type, target_name):\n",
     "    _path = \"{}/{}/{}/resources/{}/permissions\".format(MAGPIE_URL, target_type, target_name, resource_id)\n",
@@ -475,7 +558,9 @@
     "               .format(permission, target_type, target_name, resource_name, resource_id)\n",
     "        cleanup_test_data()\n",
     "        raise ValueError(response_msg(_msg, _resp))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 22
   },
   {
    "cell_type": "markdown",
@@ -487,10 +572,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
    "id": "adcb93d0-a1ce-44f7-87b8-b9fa82a45571",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:07.214693229Z",
+     "start_time": "2026-04-03T00:02:07.193605044Z"
+    }
+   },
    "source": [
     "def has_access(path, session, user_name, expected_access):\n",
     "    _resp = session.get(path, headers = {\"Content-Type\": None, \"Cache-Control\": \"no-cache\"})\n",
@@ -515,55 +603,38 @@
     "          \"  Access:   [Error]\".format(path, user_name, _code))\n",
     "    _msg = \"Unexpected status code during access to resource [{}]\".format(path)\n",
     "    raise ValueError(response_msg(_msg, _resp, is_json=False))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 23
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
    "id": "ac0ac626-dab2-4956-acf0-420da7d0ba47",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:08.359640437Z",
+     "start_time": "2026-04-03T00:02:07.930260518Z"
+    }
+   },
    "source": [
     "# Prepare permissions, make sure permissions are denied for the test users before testing\n",
     "set_permission(\"getfeature-deny-recursive\", geoserver_res_id, GEOSERVER_SERVICE, \"users\", MAGPIE_TEST_USER)\n",
     "set_permission(\"getfeature-deny-recursive\", geoserver_res_id, GEOSERVER_SERVICE, \"users\", MAGPIE_NO_PERM_USER)\n",
     "set_permission(\"describestoredqueries-deny-recursive\", geoserver_res_id, GEOSERVER_SERVICE, \"users\", MAGPIE_TEST_USER)\n",
     "set_permission(\"describestoredqueries-deny-recursive\", geoserver_res_id, GEOSERVER_SERVICE, \"users\", MAGPIE_NO_PERM_USER)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 24
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
    "id": "34f49eff-d303-4ab8-9e1c-838a00ce7912",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
-      "  User:     [test-user-58d91ff0-48d8-42fe-a121-29302959b295]\n",
-      "  Code:     [403]\n",
-      "  Access:   [Denied]\n",
-      "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
-      "  User:     [test-user-no-perm-aadee8c3-d416-4d67-965b-5d3d2bc45591]\n",
-      "  Code:     [403]\n",
-      "  Access:   [Denied]\n",
-      "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
-      "  User:     [test-user-58d91ff0-48d8-42fe-a121-29302959b295]\n",
-      "  Code:     [200]\n",
-      "  Access:   [Allowed]\n",
-      "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
-      "  User:     [test-user-no-perm-aadee8c3-d416-4d67-965b-5d3d2bc45591]\n",
-      "  Code:     [403]\n",
-      "  Access:   [Denied]\n"
-     ]
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:11.212719647Z",
+     "start_time": "2026-04-03T00:02:09.465985547Z"
     }
-   ],
+   },
    "source": [
     "# Test on workspace resource\n",
     "res_path = f\"{GEOSERVER_URL}/{workspace_name}/wfs?typeNames={workspace_name}:{shapefile_name}&request=GetFeature\"\n",
@@ -575,41 +646,46 @@
     "\n",
     "has_access(res_path, test_user_session, MAGPIE_TEST_USER, True)\n",
     "has_access(res_path, no_perm_user_session, MAGPIE_NO_PERM_USER, False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "9b84715b-34a2-4a68-be2b-128b4cda7d40",
-   "metadata": {},
+   ],
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
-      "  User:     [test-user-58d91ff0-48d8-42fe-a121-29302959b295]\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
+      "  User:     [test-user-0e79b392-ce91-429c-a66c-e6242a3d7870]\n",
       "  Code:     [403]\n",
       "  Access:   [Denied]\n",
       "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
-      "  User:     [test-user-no-perm-aadee8c3-d416-4d67-965b-5d3d2bc45591]\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
+      "  User:     [test-user-no-perm-c0d7a4f1-8f42-484c-935a-c01f6e6b1a02]\n",
       "  Code:     [403]\n",
       "  Access:   [Denied]\n",
       "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
-      "  User:     [test-user-58d91ff0-48d8-42fe-a121-29302959b295]\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
+      "  User:     [test-user-0e79b392-ce91-429c-a66c-e6242a3d7870]\n",
       "  Code:     [200]\n",
       "  Access:   [Allowed]\n",
       "Detail:\n",
-      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
-      "  User:     [test-user-no-perm-aadee8c3-d416-4d67-965b-5d3d2bc45591]\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=GetFeature]\n",
+      "  User:     [test-user-no-perm-c0d7a4f1-8f42-484c-935a-c01f6e6b1a02]\n",
       "  Code:     [403]\n",
       "  Access:   [Denied]\n"
      ]
     }
    ],
+   "execution_count": 25
+  },
+  {
+   "cell_type": "code",
+   "id": "9b84715b-34a2-4a68-be2b-128b4cda7d40",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-03T00:02:15.875442861Z",
+     "start_time": "2026-04-03T00:02:15.635758853Z"
+    }
+   },
    "source": [
     "# Test on layer resource\n",
     "res_path = f\"{GEOSERVER_URL}/{workspace_name}/wfs?typeNames={workspace_name}:{shapefile_name}&request=DescribeStoredQueries\"\n",
@@ -621,7 +697,36 @@
     "\n",
     "has_access(res_path, test_user_session, MAGPIE_TEST_USER, True)\n",
     "has_access(res_path, no_perm_user_session, MAGPIE_NO_PERM_USER, False)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Detail:\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
+      "  User:     [test-user-0e79b392-ce91-429c-a66c-e6242a3d7870]\n",
+      "  Code:     [403]\n",
+      "  Access:   [Denied]\n",
+      "Detail:\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
+      "  User:     [test-user-no-perm-c0d7a4f1-8f42-484c-935a-c01f6e6b1a02]\n",
+      "  Code:     [403]\n",
+      "  Access:   [Denied]\n",
+      "Detail:\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
+      "  User:     [test-user-0e79b392-ce91-429c-a66c-e6242a3d7870]\n",
+      "  Code:     [200]\n",
+      "  Access:   [Allowed]\n",
+      "Detail:\n",
+      "  Resource: [https://pavics.ouranos.ca/geoserver/test_workspace/wfs?typeNames=test_workspace:Espace_Vert&request=DescribeStoredQueries]\n",
+      "  User:     [test-user-no-perm-c0d7a4f1-8f42-484c-935a-c01f6e6b1a02]\n",
+      "  Code:     [403]\n",
+      "  Access:   [Denied]\n"
+     ]
+    }
+   ],
+   "execution_count": 26
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
# Overview

Fix geoserver workspace and datastore setup for auth test.

## Changes

- Fix geoserver workspace and datastore setup for auth test, by POSTing directly the datastore configuration which is now required (at least the "shapefile URL" is), rather than providing it after the fact by PUT. 
- Added a pre-check of components to warn in case of misconfiguration being detected for normal usage of the notebook. The pre-check is non-failing to allow testing other variants. This is not critical since any other setup would fail the operation anyway in later cell if overall behaviour is not as expected.



## Related Issue / Discussion

ℹ️ tested on local instance for now

- CI Job: ~http://daccs-jenkins.crim.ca/job/DACCS-iac-birdhouse/4143/~
- http://daccs-jenkins.crim.ca/job/DACCS-iac-birdhouse/4151
  - using https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/tree/fix-geoserver-setup
  - using https://github.com/bird-house/birdhouse-deploy/tree/upgrade-geoserver 
  - testing only https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests with all others disabled

✅ http://daccs-jenkins.crim.ca/job/PAVICS-e2e-workflow-tests/job/fix-geoserver-setup/2/console
```
10:55:22  + py.test --rootdir=. --nbval notebooks-auth/geoserver.ipynb notebooks-auth/test_cowbird_jupyter.ipynb notebooks-auth/test_thredds.ipynb notebooks/hummingbird.ipynb notebooks/stress-tests.ipynb --nbval-sanitize-with notebooks/output-sanitize.cfg --dist=loadscope --numprocesses=0
10:55:26  ============================= test session starts ==============================
10:55:26  platform linux -- Python 3.11.12, pytest-8.3.5, pluggy-1.5.0
10:55:26  rootdir: /home/jenkins/agent/workspace/rkflow-tests_fix-geoserver-setup
10:55:26  plugins: anyio-4.9.0, dash-3.0.3, nbval-0.11.0, tornasync-0.6.0.post2, xdist-3.6.1
10:55:26  collected 57 items
10:55:26  
10:55:32  notebooks-auth/geoserver.ipynb ..................                        [ 31%]
10:56:33  notebooks-auth/test_cowbird_jupyter.ipynb ..........                     [ 49%]
10:56:36  notebooks-auth/test_thredds.ipynb ...........                            [ 68%]
10:56:38  notebooks/hummingbird.ipynb ............                                 [ 89%]
10:59:02  notebooks/stress-tests.ipynb ......                                      [100%]
10:59:02  
10:59:02  ======================== 57 passed in 213.19s (0:03:33) ========================
```
 

- Other issues found while working on this one
  - closes #155 
  - relates to https://github.com/bird-house/birdhouse-deploy/pull/570

