### PR TITLE
tuto nb deploy: add recursively all of pavics-sdi `PAVICS-training` folder

### DIFF
--- a/binder/reorg-notebooks
+++ b/binder/reorg-notebooks
@@ -26,6 +26,7 @@ fi
 rm -r PAVICS-landing-$PAVICS_LANDING_BRANCH
 
 mv -v pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/*.ipynb ./
+mv -v pavics-sdi-$PAVICS_SDI_BRANCH/docs/source/notebooks/PAVICS-training ./
 rm -r pavics-sdi-$PAVICS_SDI_BRANCH
 
 mv -v finch-$FINCH_BRANCH/docs/source/notebooks/*.ipynb ./


### PR DESCRIPTION
Note this just add to deployed tutorial nbs, this do not enable these nbs on Jenkins

Related to https://github.com/Ouranosinc/pavics-sdi/pull/382#pullrequestreview-4101398910

<img width="397" height="233" alt="Screenshot from 2026-04-14 16-59-54" src="https://github.com/user-attachments/assets/7f5abdd8-0059-4929-b4bc-3b8fb9ab20a6" />
<img width="512" height="223" alt="Screenshot from 2026-04-14 17-00-04" src="https://github.com/user-attachments/assets/da8a05a7-5a73-4a83-a84b-5712dd1df362" />
<img width="405" height="249" alt="Screenshot from 2026-04-14 17-00-18" src="https://github.com/user-attachments/assets/5dddf7c6-d1be-49c4-82df-82b6de46a1c9" />
