### PR TITLE
Nbval timeout adjustment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,8 @@ Requires 'weaver' component to be active on the target 'PAVICS_HOST' server
                 description: 'ESGF_COMPUTE_API_REPO branch to test against.', trim: true)
         string(name: 'ESGF_COMPUTE_API_REPO', defaultValue: 'ESGF/esgf-compute-api',
                 description: 'https://github.com/ESGF/esgf-compute-api repo or fork to test against.', trim: true)
+        string(name: 'PYTEST_NBVAL_NOTEBOOK_TIMEOUT', defaultValue: '300',
+                description: "Timeout in sec for pytest --nbval-cell-timeout. For slow notebooks or slow machine", trim: true)        
         string(name: 'PYTEST_EXTRA_OPTS', defaultValue: '--dist=loadscope --numprocesses=0',
                 description: 'Extra options to pass to pytest, e.g. --nbval-lax --dist=loadscope --numprocesses=0', trim: true)
         string(name: 'EXTRA_TEST_ENV_VAR', defaultValue: '',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ Requires 'weaver' component to be active on the target 'PAVICS_HOST' server
         booleanParam(name: 'SAVE_RESULTING_NOTEBOOK', defaultValue: true,
                 description: '''Check the box to save the resulting notebooks of the run.
 Note this is another run, will double the time and no guaranty to have same error as the run from py.test.''')
-        string(name: 'SAVE_RESULTING_NOTEBOOK_TIMEOUT', defaultValue: '240',
+        string(name: 'SAVE_RESULTING_NOTEBOOK_TIMEOUT', defaultValue: '300',
                 description: 'Timeout in sec for nbconvert.  For slow notebooks or slow machine', trim: true)
     }
 

--- a/runtest
+++ b/runtest
@@ -57,7 +57,7 @@ handle_config_override_script_url "$CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL"
 handle_config_override_script_url "$CONFIG_OVERRIDE_SCRIPT_URL"
 
 # CONFIG_OVERRIDE_SCRIPT_URL can override NBVAL_SANITIZE_CFG_FILE.
-py.test --rootdir=. --nbval $NOTEBOOKS --nbval-sanitize-with="${NBVAL_SANITIZE_CFG_FILE:=notebooks/output-sanitize.cfg}" --nbval-cell-timeout="${PYTEST_NBVAL_NOTEBOOK_TIMEOUT}" $PYTEST_EXTRA_OPTS
+py.test --rootdir=. --nbval $NOTEBOOKS --nbval-sanitize-with="${NBVAL_SANITIZE_CFG_FILE:=notebooks/output-sanitize.cfg}" --nbval-cell-timeout="${PYTEST_NBVAL_NOTEBOOK_TIMEOUT:=300}" $PYTEST_EXTRA_OPTS
 EXIT_CODE="$?"
 
 # lowercase SAVE_RESULTING_NOTEBOOK string
@@ -102,7 +102,7 @@ for nb in $RESULTING_NOTEBOOKS; do
         # for them to run.  If more than 4 mins, in addition to simplifying the
         # notebook, should also check machine performance.
         jupyter nbconvert --to notebook --execute \
-            --ExecutePreprocessor.timeout=${SAVE_RESULTING_NOTEBOOK_TIMEOUT:=240} --allow-errors \
+            --ExecutePreprocessor.timeout=${SAVE_RESULTING_NOTEBOOK_TIMEOUT:=300} --allow-errors \
             --output-dir "${BUILDOUT_DIR}" --output "${filename}.output.ipynb" "$nb"
     fi
 done

--- a/runtest
+++ b/runtest
@@ -57,7 +57,7 @@ handle_config_override_script_url "$CI_OVERRIDE_CONFIG_OVERRIDE_SCRIPT_URL"
 handle_config_override_script_url "$CONFIG_OVERRIDE_SCRIPT_URL"
 
 # CONFIG_OVERRIDE_SCRIPT_URL can override NBVAL_SANITIZE_CFG_FILE.
-py.test --rootdir=. --nbval $NOTEBOOKS --nbval-sanitize-with "${NBVAL_SANITIZE_CFG_FILE:=notebooks/output-sanitize.cfg}" $PYTEST_EXTRA_OPTS
+py.test --rootdir=. --nbval $NOTEBOOKS --nbval-sanitize-with="${NBVAL_SANITIZE_CFG_FILE:=notebooks/output-sanitize.cfg}" --nbval-cell-timeout="${PYTEST_NBVAL_NOTEBOOK_TIMEOUT}" $PYTEST_EXTRA_OPTS
 EXIT_CODE="$?"
 
 # lowercase SAVE_RESULTING_NOTEBOOK string


### PR DESCRIPTION
# Overview

<!-- Please include a summary of the changes and which issues is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes [154](https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/issues/154) by adjusting the timeout for `nbsphinx` to be 60 seconds longer, as well as adds a field to Jenkins for manually setting `--nbval-cell-timeout` (set to 300 seconds by default)

## Changes

- Adds an execution parameter for Jenkins to set `pytest --nbval` timeout.

## Additional Information

Unfortunately, this feature doesn't yet seem to be implemented as of writing: https://github.com/computationalmodelling/nbval/issues/151