### PR TITLE
Extract the conda environment configuration, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: "quarterly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - patch
+          - minor
+          - major
+    cooldown:
+      default-days: 7

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  TEST_TAG: workflow-tests:latest
+  TEST_TAG: workflow-tests:test
 
 jobs:
   build:
@@ -42,8 +42,8 @@ jobs:
       - name: Gather artifacts
         run: |
           docker create --name test ${{ env.TEST_TAG }}
-          mkdir ./build-artifacts
-          docker cp test:/conda-env-export-final.yml ./build-artifacts/conda-env-export.yml
+          mkdir build-artifacts
+          docker cp test:/conda-env-export-final.yml build-artifacts/conda-env-export.yml
           docker rm test
 
       - name: Run Docker image
@@ -60,4 +60,4 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: conda-env-export.yml
-          path: /home/runner/work/PAVICS-e2e-workflow-tests/PAVICS-e2e-workflow-tests/build-artifacts
+          path: build-artifacts

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Gather artifacts
         run: |
           docker create --name test ${{ env.TEST_TAG }}
-          docker cp test:/conda-env-export-final.yml ./conda-env-export.yml
+          docker cp test:/conda-env-export-final.yml ./build-artifacts/conda-env-export.yml
           docker rm test
 
       - name: Run Docker image
@@ -59,3 +59,4 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: conda-env-export.yml
+          path: ./build-artifacts

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -56,8 +56,8 @@ jobs:
             # Run the test script inside the Docker container
             conda run -n birdy mamba list
 
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: conda-env-export.yml
           path: build-artifacts

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+env:
+  TEST_TAG: workflow-tests:latest
+
 jobs:
   build:
     name: Build Docker image and run smoke tests
@@ -16,28 +19,43 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit
+      
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      
       - name: Build Docker image (no push)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: "{{defaultContext}}:docker"
           file: "Dockerfile"
-          tags: workflow-tests:latest
+          tags: ${{ env.TEST_TAG }}
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: false
+
+      - name: Gather artifacts
+        run: |
+          docker create --name test ${{ env.TEST_TAG }}
+          docker cp test:/conda-env-export-final.yml ./conda-env-export.yml
+          docker rm test
+
       - name: Run Docker image
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3.0.0
         with:
-          image: workflow-tests:latest
+          image: ${{ env.TEST_TAG }}
           run: |
             set -e
             echo "Running tests in Docker container"
             # Run the test script inside the Docker container
             conda run -n birdy mamba list
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: conda-env-export.yml

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -27,7 +27,7 @@ jobs:
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-      
+
       - name: Build Docker image (no push)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -38,6 +38,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: false
+          build-args: |
+            BUILDKIT_PROGRESS=plain
 
       - name: Gather artifacts
         run: |
@@ -45,16 +47,6 @@ jobs:
           mkdir build-artifacts
           docker cp test:/conda-env-export-final.yml build-artifacts/conda-env-export.yml
           docker rm test
-
-      - name: Run Docker image
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3.0.0
-        with:
-          image: ${{ env.TEST_TAG }}
-          run: |
-            set -e
-            echo "Running tests in Docker container"
-            # Run the test script inside the Docker container
-            conda run -n birdy mamba list
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Gather artifacts
         run: |
           docker create --name test ${{ env.TEST_TAG }}
+          mkdir ./build-artifacts
           docker cp test:/conda-env-export-final.yml ./build-artifacts/conda-env-export.yml
           docker rm test
 
@@ -59,4 +60,4 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: conda-env-export.yml
-          path: ./build-artifacts
+          path: /home/runner/work/PAVICS-e2e-workflow-tests/PAVICS-e2e-workflow-tests/build-artifacts


### PR DESCRIPTION
# Overview

This PR updates the `docker-testing.yml` workflow to create archives of the `conda-env-export.yml` as well as renders the simplified build log (`docker-buildlogs.txt`) in such a way that it can be easily copy-pasted.

The build log does not include timestamps like the one available on DockerHub, so the information is easier to diff between versions.

## Changes

- Added commands and an action for uploading the `conda-env-export.yml` file
- Removed the smoke test for outputting the conda env to stdout
- Added a Dependabot configuration for keeping actions up-to-date

## Related Issue / Discussion

We should open another PR to add a similar workflow that is triggered on tags that integrates the Docker Metadata Action (https://github.com/marketplace/actions/docker-metadata-action) to build images and perform specific tag uploads to DockerHub.

## Additional Information

The Dependabot configuration only targets the workflows. There is no support for `conda` environments at this time.